### PR TITLE
[Iotdb-3469] Support set TTL in new cluster

### DIFF
--- a/client-cpp/README.md
+++ b/client-cpp/README.md
@@ -53,7 +53,7 @@ On Mac machines, the hierarchy of the package should look like this:
 +-- client
 |   +-- include
 |       +-- Session.h
-|       +-- TSIService.h
+|       +-- IClientRPCService.h
 |       +-- rpc_types.h
 |       +-- rpc_constants.h
 |       +-- thrift

--- a/client-cpp/pom.xml
+++ b/client-cpp/pom.xml
@@ -165,8 +165,8 @@
                                 <configuration>
                                     <fileSets>
                                         <fileSet>
-                                            <sourceFile>../thrift/src/main/thrift/rpc.thrift</sourceFile>
-                                            <destinationFile>${project.build.directory}/thrift/rpc.thrift</destinationFile>
+                                            <sourceFile>../thrift/src/main/thrift/client.thrift</sourceFile>
+                                            <destinationFile>${project.build.directory}/thrift/client.thrift</destinationFile>
                                         </fileSet>
                                         <fileSet>
                                             <sourceFile>../thrift-commons/src/main/thrift/common.thrift</sourceFile>

--- a/client-cpp/src/main/Session.cpp
+++ b/client-cpp/src/main/Session.cpp
@@ -614,10 +614,10 @@ void Session::open(bool enableRPCCompression, int connectionTimeoutInMs) {
     }
     if (enableRPCCompression) {
         shared_ptr<TCompactProtocol> protocol(new TCompactProtocol(transport));
-        client = std::make_shared<TSIServiceClient>(protocol);
+        client = std::make_shared<IClientRPCServiceClient>(protocol);
     } else {
         shared_ptr<TBinaryProtocol> protocol(new TBinaryProtocol(transport));
-        client = std::make_shared<TSIServiceClient>(protocol);
+        client = std::make_shared<IClientRPCServiceClient>(protocol);
     }
 
     std::map<std::string, std::string> configuration;

--- a/client-cpp/src/main/Session.h
+++ b/client-cpp/src/main/Session.h
@@ -40,7 +40,7 @@
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportException.h>
 #include <thrift/transport/TBufferTransports.h>
-#include "TSIService.h"
+#include "IClientRPCService.h"
 
 using ::apache::thrift::protocol::TBinaryProtocol;
 using ::apache::thrift::protocol::TCompactProtocol;
@@ -634,7 +634,7 @@ private:
     int64_t queryId;
     int64_t statementId;
     int64_t sessionId;
-    std::shared_ptr<TSIServiceIf> client;
+    std::shared_ptr<IClientRPCServiceIf> client;
     int batchSize = 1024;
     std::vector<std::string> columnNameList;
     std::vector<std::string> columnTypeDeduplicatedList;
@@ -664,7 +664,7 @@ public:
                    std::map<std::string, int> &columnNameIndexMap,
                    bool isIgnoreTimeStamp,
                    int64_t queryId, int64_t statementId,
-                   std::shared_ptr<TSIServiceIf> client, int64_t sessionId,
+                   std::shared_ptr<IClientRPCServiceIf> client, int64_t sessionId,
                    const std::shared_ptr<TSQueryDataSet> &queryDataSet) : tsQueryDataSetTimeBuffer(queryDataSet->time) {
         this->sessionId = sessionId;
         this->sql = sql;
@@ -893,7 +893,7 @@ private:
     std::string username;
     std::string password;
     const TSProtocolVersion::type protocolVersion = TSProtocolVersion::IOTDB_SERVICE_PROTOCOL_V3;
-    std::shared_ptr<TSIServiceIf> client;
+    std::shared_ptr<IClientRPCServiceIf> client;
     std::shared_ptr<TTransport> transport;
     bool isClosed = true;
     int64_t sessionId;

--- a/client-py/iotdb/Session.py
+++ b/client-py/iotdb/Session.py
@@ -24,7 +24,7 @@ from thrift.transport import TSocket, TTransport
 from iotdb.utils.SessionDataSet import SessionDataSet
 from .template.Template import Template
 from .template.TemplateQueryType import TemplateQueryType
-from .thrift.rpc.TSIService import (
+from .thrift.rpc.IClientRPCService import (
     Client,
     TSCreateTimeseriesReq,
     TSCreateAlignedTimeseriesReq,
@@ -61,7 +61,7 @@ from .thrift.rpc.ttypes import (
 # from thrift.protocol import TBinaryProtocol, TCompactProtocol
 # from thrift.transport import TSocket, TTransport
 #
-# from iotdb.rpc.TSIService import Client, TSCreateTimeseriesReq, TSInsertRecordReq, TSInsertTabletReq, \
+# from iotdb.rpc.IClientRPCService import Client, TSCreateTimeseriesReq, TSInsertRecordReq, TSInsertTabletReq, \
 #      TSExecuteStatementReq, TSOpenSessionReq, TSQueryDataSet, TSFetchResultsReq, TSCloseOperationReq, \
 #      TSCreateMultiTimeseriesReq, TSCloseSessionReq, TSInsertTabletsReq, TSInsertRecordsReq
 # from iotdb.rpc.ttypes import TSDeleteDataReq, TSProtocolVersion, TSSetTimeZoneReq

--- a/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -23,7 +23,7 @@ import logging
 import numpy as np
 import pandas as pd
 from thrift.transport import TTransport
-from iotdb.thrift.rpc.TSIService import TSFetchResultsReq, TSCloseOperationReq
+from iotdb.thrift.rpc.IClientRPCService import TSFetchResultsReq, TSCloseOperationReq
 from iotdb.utils.IoTDBConstants import TSDataType
 
 logger = logging.getLogger("IoTDB")

--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -48,13 +48,26 @@ target_config_nodes=0.0.0.0:22277
 
 
 ####################
-### Consensus protocol configuration
+### Region configuration
 ####################
 
-# All parameters in Consensus protocol configuration is unmodifiable after ConfigNode starts for the first time.
-# And these parameters should be consistent within the ConfigNodeGroup.
 
-# DataRegion consensus protocol type
+# SchemaRegion consensus protocol type.
+# This parameter is unmodifiable after ConfigNode starts for the first time.
+# These consensus protocols are currently supported:
+# 1. org.apache.iotdb.consensus.standalone.StandAloneConsensus(Consensus patterns optimized specifically for single replica)
+# 2. org.apache.iotdb.consensus.ratis.RatisConsensus(Raft protocol)
+# Datatype: String
+# schema_region_consensus_protocol_class=org.apache.iotdb.consensus.standalone.StandAloneConsensus
+
+# The maximum number of SchemaRegion expected to be managed by each DataNode.
+# Notice: Since each StorageGroup requires at least one SchemaRegion to manage it's schema,
+# this parameter doesn't limit the number of SchemaRegions when there are too many StorageGroups.
+# Datatype: Double
+# schema_region_per_data_node=1.0
+
+# DataRegion consensus protocol type.
+# This parameter is unmodifiable after ConfigNode starts for the first time.
 # These consensus protocols are currently supported:
 # 1. org.apache.iotdb.consensus.standalone.StandAloneConsensus(Consensus patterns optimized specifically for single replica)
 # 2. org.apache.iotdb.consensus.multileader.MultiLeaderConsensus(weak consistency, high performance)
@@ -62,12 +75,11 @@ target_config_nodes=0.0.0.0:22277
 # Datatype: String
 # data_region_consensus_protocol_class=org.apache.iotdb.consensus.standalone.StandAloneConsensus
 
-# SchemaRegion consensus protocol type
-# These consensus protocols are currently supported:
-# 1. org.apache.iotdb.consensus.standalone.StandAloneConsensus(Consensus patterns optimized specifically for single replica)
-# 2. org.apache.iotdb.consensus.ratis.RatisConsensus(Raft protocol)
-# Datatype: String
-# schema_region_consensus_protocol_class=org.apache.iotdb.consensus.standalone.StandAloneConsensus
+# The maximum number of SchemaRegion expected to be managed by each processor.
+# Notice: Since each StorageGroup requires at least two DataRegions to manage it's data,
+# this parameter doesn't limit the number of DataRegions when there are too many StorageGroups.
+# Datatype: Double
+# data_region_per_processor=0.5
 
 ####################
 ### PartitionSlot configuration

--- a/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -37,14 +37,14 @@ rpc_port=22277
 consensus_port=22278
 
 
-# Used for connecting to the ConfigNodeGroup
+# At least one running ConfigNode should be set for joining the cluster
 # Format: ip:port
 # where the ip should be consistent with the target ConfigNode's confignode_rpc_address,
 # and the port should be consistent with the target ConfigNode's confignode_rpc_port.
-# For the first ConfigNode to start, config_nodes points to its own ip:port.
-# For other ConfigNodes that are started or restarted, config_nodes points to any running ConfigNode's ip:port.
+# For the first ConfigNode to start, target_config_nodes points to its own ip:port.
+# For other ConfigNodes that are started or restarted, target_config_nodes points to any running ConfigNode's ip:port.
 # Datatype: String
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 
 
 ####################

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -58,11 +58,17 @@ public class ConfigNodeConfig {
   /** ConfigNodeGroup consensus protocol */
   private String configNodeConsensusProtocolClass = ConsensusFactory.RatisConsensus;
 
+  /** DataNode schema region consensus protocol */
+  private String schemaRegionConsensusProtocolClass = ConsensusFactory.StandAloneConsensus;
+
+  /** The maximum number of SchemaRegion expected to be managed by each DataNode. */
+  private double schemaRegionPerDataNode = 1.0;
+
   /** DataNode data region consensus protocol */
   private String dataRegionConsensusProtocolClass = ConsensusFactory.StandAloneConsensus;
 
-  /** DataNode schema region consensus protocol */
-  private String schemaRegionConsensusProtocolClass = ConsensusFactory.StandAloneConsensus;
+  /** The maximum number of SchemaRegion expected to be managed by each DataNode. */
+  private double dataRegionPerProcessor = 0.5;
 
   /**
    * ClientManager will have so many selector threads (TAsyncClientManager) to distribute to its
@@ -320,6 +326,22 @@ public class ConfigNodeConfig {
     this.configNodeConsensusProtocolClass = configNodeConsensusProtocolClass;
   }
 
+  public String getSchemaRegionConsensusProtocolClass() {
+    return schemaRegionConsensusProtocolClass;
+  }
+
+  public void setSchemaRegionConsensusProtocolClass(String schemaRegionConsensusProtocolClass) {
+    this.schemaRegionConsensusProtocolClass = schemaRegionConsensusProtocolClass;
+  }
+
+  public double getSchemaRegionPerDataNode() {
+    return schemaRegionPerDataNode;
+  }
+
+  public void setSchemaRegionPerDataNode(double schemaRegionPerDataNode) {
+    this.schemaRegionPerDataNode = schemaRegionPerDataNode;
+  }
+
   public String getDataRegionConsensusProtocolClass() {
     return dataRegionConsensusProtocolClass;
   }
@@ -328,12 +350,12 @@ public class ConfigNodeConfig {
     this.dataRegionConsensusProtocolClass = dataRegionConsensusProtocolClass;
   }
 
-  public String getSchemaRegionConsensusProtocolClass() {
-    return schemaRegionConsensusProtocolClass;
+  public double getDataRegionPerProcessor() {
+    return dataRegionPerProcessor;
   }
 
-  public void setSchemaRegionConsensusProtocolClass(String schemaRegionConsensusProtocolClass) {
-    this.schemaRegionConsensusProtocolClass = schemaRegionConsensusProtocolClass;
+  public void setDataRegionPerProcessor(double dataRegionPerProcessor) {
+    this.dataRegionPerProcessor = dataRegionPerProcessor;
   }
 
   public int getThriftServerAwaitTimeForStopService() {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -115,9 +115,10 @@ public class ConfigNodeDescriptor {
           Integer.parseInt(
               properties.getProperty("consensus_port", String.valueOf(conf.getConsensusPort()))));
 
-      String targetConfigNode = properties.getProperty("config_nodes", null);
-      if (targetConfigNode != null) {
-        conf.setTargetConfigNode(NodeUrlUtils.parseTEndPointUrl(targetConfigNode));
+      // TODO: Enable multiple target_config_nodes
+      String targetConfigNodes = properties.getProperty("target_config_nodes", null);
+      if (targetConfigNodes != null) {
+        conf.setTargetConfigNode(NodeUrlUtils.parseTEndPointUrl(targetConfigNodes));
       }
 
       conf.setSeriesPartitionSlotNum(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -134,14 +134,25 @@ public class ConfigNodeDescriptor {
           properties.getProperty(
               "config_node_consensus_protocol_class", conf.getConfigNodeConsensusProtocolClass()));
 
-      conf.setDataRegionConsensusProtocolClass(
-          properties.getProperty(
-              "data_region_consensus_protocol_class", conf.getDataRegionConsensusProtocolClass()));
-
       conf.setSchemaRegionConsensusProtocolClass(
           properties.getProperty(
               "schema_region_consensus_protocol_class",
               conf.getSchemaRegionConsensusProtocolClass()));
+
+      conf.setSchemaRegionPerDataNode(
+          Double.parseDouble(
+              properties.getProperty(
+                  "schema_region_per_data_node",
+                  String.valueOf(conf.getSchemaRegionPerDataNode()))));
+
+      conf.setDataRegionConsensusProtocolClass(
+          properties.getProperty(
+              "data_region_consensus_protocol_class", conf.getDataRegionConsensusProtocolClass()));
+
+      conf.setDataRegionPerProcessor(
+          Double.parseDouble(
+              properties.getProperty(
+                  "data_region_per_processor", String.valueOf(conf.getDataRegionPerProcessor()))));
 
       conf.setRpcAdvancedCompressionEnable(
           Boolean.parseBoolean(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -83,12 +83,12 @@ public class ConfigNodeStartupCheck {
   /** Check whether the global configuration of the cluster is correct */
   private void checkGlobalConfig() throws ConfigurationException {
     // When the ConfigNode consensus protocol is set to StandAlone,
-    // the config_nodes needs to point to itself
+    // the target_config_nodes needs to point to itself
     if (conf.getConfigNodeConsensusProtocolClass().equals(ConsensusFactory.StandAloneConsensus)
         && (!conf.getRpcAddress().equals(conf.getTargetConfigNode().getIp())
             || conf.getRpcPort() != conf.getTargetConfigNode().getPort())) {
       throw new ConfigurationException(
-          "config_nodes",
+          "target_config_nodes",
           conf.getTargetConfigNode().getIp() + ":" + conf.getTargetConfigNode().getPort(),
           conf.getRpcAddress() + ":" + conf.getRpcPort());
     }
@@ -160,7 +160,7 @@ public class ConfigNodeStartupCheck {
    * Check if the current ConfigNode is SeedConfigNode. If true, do the SeedConfigNode configuration
    * as well.
    *
-   * @return True if the config_nodes points to itself
+   * @return True if the target_config_nodes points to itself
    */
   private boolean isSeedConfigNode() {
     boolean result =

--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -193,7 +193,9 @@ public class ConfigNodeStartupCheck {
             CommonDescriptor.getInstance().getConfig().getDefaultTTL(),
             conf.getTimePartitionInterval(),
             conf.getSchemaReplicationFactor(),
-            conf.getDataReplicationFactor());
+            conf.getSchemaRegionPerDataNode(),
+            conf.getDataReplicationFactor(),
+            conf.getDataRegionPerProcessor());
 
     TEndPoint targetConfigNode = conf.getTargetConfigNode();
     while (true) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterSchemaManager.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.read.CountStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.read.GetStorageGroupReq;
 import org.apache.iotdb.confignode.consensus.request.write.AdjustMaxRegionGroupCountReq;
@@ -48,6 +49,11 @@ import java.util.Map;
 public class ClusterSchemaManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterSchemaManager.class);
+
+  private static final double schemaRegionPerDataNode =
+      ConfigNodeDescriptor.getInstance().getConf().getSchemaRegionPerDataNode();
+  private static final double dataRegionPerProcessor =
+      ConfigNodeDescriptor.getInstance().getConf().getDataRegionPerProcessor();
 
   private final IManager configManager;
   private final ClusterSchemaInfo clusterSchemaInfo;
@@ -164,8 +170,12 @@ public class ClusterSchemaManager {
             Math.max(
                 1,
                 Math.max(
-                    dataNodeNum
-                        / (storageGroupNum * storageGroupSchema.getSchemaReplicationFactor()),
+                    (int)
+                        (schemaRegionPerDataNode
+                            * dataNodeNum
+                            / (double)
+                                (storageGroupNum
+                                    * storageGroupSchema.getSchemaReplicationFactor())),
                     allocatedSchemaRegionGroupCount));
 
         // Adjust maxDataRegionGroupCount.
@@ -178,8 +188,11 @@ public class ClusterSchemaManager {
             Math.max(
                 2,
                 Math.max(
-                    totalCpuCoreNum
-                        / (3 * storageGroupNum * storageGroupSchema.getDataReplicationFactor()),
+                    (int)
+                        (dataRegionPerProcessor
+                            * totalCpuCoreNum
+                            / (double)
+                                (storageGroupNum * storageGroupSchema.getDataReplicationFactor())),
                     allocatedDataRegionGroupCount));
 
         adjustMaxRegionGroupCountReq.putEntry(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -665,11 +665,25 @@ public class ConfigManager implements IManager {
               "Reject register, please ensure that the schema_replication_factor are consistent.");
       return errorResp;
     }
+    if (req.getSchemaRegionPerDataNode() != conf.getSchemaRegionPerDataNode()) {
+      errorResp
+          .getStatus()
+          .setMessage(
+              "Reject register, please ensure that the schema_region_per_data_node are consistent.");
+      return errorResp;
+    }
     if (req.getDataReplicationFactor() != conf.getDataReplicationFactor()) {
       errorResp
           .getStatus()
           .setMessage(
               "Reject register, please ensure that the data_replication_factor are consistent.");
+      return errorResp;
+    }
+    if (req.getDataRegionPerProcessor() != conf.getDataRegionPerProcessor()) {
+      errorResp
+          .getStatus()
+          .setMessage(
+              "Reject register, please ensure that the data_region_per_processor are consistent.");
       return errorResp;
     }
     return null;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
-import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
+import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 
 /** ConfigNodeRPCServer exposes the interface that interacts with the DataNode */
 public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPCServiceMBean {
@@ -53,7 +53,7 @@ public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPC
 
   @Override
   public void initTProcessor() throws InstantiationException {
-    processor = new ConfigIService.Processor<>(configNodeRPCServiceProcessor);
+    processor = new IConfigNodeRPCService.Processor<>(configNodeRPCServiceProcessor);
   }
 
   @Override

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -51,7 +51,7 @@ import org.apache.iotdb.confignode.consensus.response.RegionInfoListResp;
 import org.apache.iotdb.confignode.consensus.response.StorageGroupSchemaResp;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.ConsensusManager;
-import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
+import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.confignode.rpc.thrift.TAuthorizerReq;
 import org.apache.iotdb.confignode.rpc.thrift.TAuthorizerResp;
 import org.apache.iotdb.confignode.rpc.thrift.TCheckUserPrivilegesReq;
@@ -101,7 +101,7 @@ import java.util.Collections;
 import java.util.List;
 
 /** ConfigNodeRPCServer exposes the interface that interacts with the DataNode */
-public class ConfigNodeRPCServiceProcessor implements ConfigIService.Iface {
+public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Iface {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigNodeRPCServiceProcessor.class);
 

--- a/confignode/src/test/java/org/apache/iotdb/confignode/cli/TemporaryClientDemo.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/cli/TemporaryClientDemo.java
@@ -19,7 +19,7 @@
 package org.apache.iotdb.confignode.cli;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
+import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.confignode.rpc.thrift.TSetStorageGroupReq;
 import org.apache.iotdb.confignode.rpc.thrift.TStorageGroupSchema;
 import org.apache.iotdb.rpc.RpcTransportFactory;
@@ -39,8 +39,8 @@ public class TemporaryClientDemo {
   private static final int timeOutInMS = 10000;
 
   private final Random random = new Random();
-  private Map<Integer, ConfigIService.Client> clients;
-  private ConfigIService.Client defaultClient;
+  private Map<Integer, IConfigNodeRPCService.Client> clients;
+  private IConfigNodeRPCService.Client defaultClient;
 
   public void setStorageGroupsDemo() throws TException {
     createClients();
@@ -70,7 +70,7 @@ public class TemporaryClientDemo {
     for (int i = 22277; i <= 22281; i += 2) {
       TTransport transport = RpcTransportFactory.INSTANCE.getTransport("0.0.0.0", i, timeOutInMS);
       transport.open();
-      clients.put(i, new ConfigIService.Client(new TBinaryProtocol(transport)));
+      clients.put(i, new IConfigNodeRPCService.Client(new TBinaryProtocol(transport)));
     }
   }
 }

--- a/confignode/src/test/resources/confignode1conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode1conf/iotdb-confignode.properties
@@ -20,7 +20,7 @@
 rpc_address=0.0.0.0
 rpc_port=22277
 consensus_port=22278
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus

--- a/confignode/src/test/resources/confignode2conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode2conf/iotdb-confignode.properties
@@ -20,7 +20,7 @@
 rpc_address=0.0.0.0
 rpc_port=22279
 consensus_port=22280
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus

--- a/confignode/src/test/resources/confignode3conf/iotdb-confignode.properties
+++ b/confignode/src/test/resources/confignode3conf/iotdb-confignode.properties
@@ -20,7 +20,7 @@
 rpc_address=0.0.0.0
 rpc_port=22281
 consensus_port=22282
-config_nodes=0.0.0.0:22277
+target_config_nodes=0.0.0.0:22277
 config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus

--- a/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -525,7 +525,7 @@ public class RatisConfig {
       private SizeInBytes preallocatedSize = SizeInBytes.valueOf("4MB");
       private SizeInBytes writeBufferSize = SizeInBytes.valueOf("64KB");
       private int forceSyncNum = 128;
-      private boolean unsafeFlushEnabled = false;
+      private boolean unsafeFlushEnabled = true;
 
       public Log build() {
         return new Log(

--- a/docs/UserGuide/Cluster/Cluster-Concept.md
+++ b/docs/UserGuide/Cluster/Cluster-Concept.md
@@ -27,7 +27,7 @@ Apache IoTDB Cluster contains two types of nodes: ConfigNode and DataNode, each 
 
 A illustrate of the cluster architecture：
 
-<img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Architecture.png?raw=true">
+<img style="width:100%; max-width:500px; max-height:400px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Architecture.png?raw=true">
 
 ConfigNode is the control node of the cluster, which manage the node status of cluster, partition information, etc. All ConfigNodes in the cluster form a high available group, which is fully replicated.
 
@@ -38,7 +38,7 @@ Client could only connect to the DataNode for operation.
 ## Characteristics of Cluster
 
 * Native Cluster Architecture
-    * All module is designed for the IoTDB cluster.
+    * All modules are designed for cluster.
     * Standalone is a special form of Cluster.
 * High Scalability
     * Support add nodes in a few seconds without data migration.
@@ -81,7 +81,7 @@ A region is the basic unit of replication. Multiple replicas of a region constru
 
 A illustration of the partition allocation in cluster:
 
-<img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Data-Partition.png?raw=true">
+<img style="width:100%; max-width:500px; max-height:500px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Data-Partition.png?raw=true">
 
 The figure contains 1 SchemaRegion group, and the schema_replication_factor is 3, so the 3 white SchemaRegion-0s form a replication group, and the Raft protocol is used to ensure data consistency.
 
@@ -95,3 +95,7 @@ Among multiple replicas of each region group, data consistency is guaranteed thr
   * Standalone：Could only be used when replica is 1, which is the empty implementation of the consensus protocol.
   * MultiLeader：Could be used in any number of replicas, only for DataRegion, writes can be applied on each replica and replicated asynchronously to other replicas.
   * Ratis：Raft consensus protocol, Could be used in any number of replicas, could be used for any region groups。
+  
+## 0.14.0-preview1 Function Map
+
+<img style="width:100%; max-width:800px; max-height:1000px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Preview1-Function.png?raw=true">

--- a/docs/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/UserGuide/Cluster/Cluster-Setup.md
@@ -89,7 +89,7 @@ Important parameters in iotdb-confignode.properties:
 | rpc\_address    | Internal rpc service address of ConfigNode          |
 | rpc\_port    | Internal rpc service address of ConfigNode       |
 | consensus\_port    | ConfigNode replication consensus protocol communication port    |
-| config\_nodes    | Target ConfigNode address, if the current is the first ConfigNode, then set its address:port    |
+| target\_config\_nodes    | Target ConfigNode address, if the current is the first ConfigNode, then set its address:port    |
 | data\_replication\_factor  | Data replication factor, no more than DataNode number        |
 | data\_region\_consensus\_protocol\_class | Consensus protocol of data replicas |
 | schema\_replication\_factor  | Schema replication factor, no more than DataNode number       |
@@ -116,6 +116,6 @@ Important parameters in iotdb-datanode.properties
 | mpp\_data\_exchange\_port    | Data flow port of DataNode inside cluster           |
 | data\_region\_consensus\_port    | Data replicas communication port for consensus     |
 | schema\_region\_consensus\_port    | Schema replicas communication port for consensus          |
-| config\_nodes    | Running ConfigNode of the Cluster      |
+| target\_config\_nodes    | Running ConfigNode of the Cluster      |
 
 More details [DataNode Configurations](https://iotdb.apache.org/UserGuide/Master/Reference/DataNode-Config-Manual.html)

--- a/docs/UserGuide/Reference/ConfigNode-Config-Manual.md
+++ b/docs/UserGuide/Reference/ConfigNode-Config-Manual.md
@@ -85,9 +85,9 @@ IoTDB Cluster configuration is in ConfigNode.
 |Default| 6667 |
 |Effective|After restarting system|
 
-* config\_nodes
+* target\_config\_nodes
 
-|Name| config\_nodes |
+|Name| target\_config\_nodes |
 |:---:|:---|
 |Description| Target ConfigNode address, for current ConfigNode to join the cluster |
 |Type| String |

--- a/docs/UserGuide/Reference/DataNode-Config-Manual.md
+++ b/docs/UserGuide/Reference/DataNode-Config-Manual.md
@@ -247,9 +247,9 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |Default| 50010 |
 |Effective|After restarting system|
 
-* config\_nodes
+* target\_config\_nodes
 
-|Name| config\_nodes |
+|Name| target\_config\_nodes |
 |:---:|:---|
 |Description| ConfigNode Address for DataNode to join cluster |
 |Type| String |

--- a/docs/zh/UserGuide/Cluster/Cluster-Concept.md
+++ b/docs/zh/UserGuide/Cluster/Cluster-Concept.md
@@ -27,7 +27,7 @@ Apache IoTDB 集群版包含两种角色的节点，ConfigNode 和 DataNode，�
 
 集群架构示例如下图：
 
-<img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Architecture.png?raw=true">
+<img style="width:100%; max-width:500px; max-height:400px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Architecture.png?raw=true">
 
 ConfigNode 是集群的控制节点，管理集群的节点状态、分区信息等，集群所有 ConfigNode 组成一个高可用组，数据全量备份。
 
@@ -82,7 +82,7 @@ Region 是数据复制的基本单位，一个 Region 的多个副本构成了�
 
 完整的集群分区复制的示意图如下：
 
-<img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Data-Partition.png?raw=true">
+<img style="width:100%; max-width:500px; max-height:500px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Data-Partition.png?raw=true">
 
 图中包含 1 个 SchemaRegion 组，元数据采用 3 副本，因此 3 个白色的 SchemaRegion-0 组成了一个副本组。
 
@@ -96,3 +96,7 @@ Region 是数据复制的基本单位，一个 Region 的多个副本构成了�
     * Standalone：仅单副本时可用，一致性协议的空实现，效率最高。
     * MultiLeader：任意副本数可用，当前仅可用于 DataRegion 的副本上，写入可以在任一副本进行，并异步复制到其他副本。
     * Ratis：Raft 协议的一种实现，任意副本数可用，当前可用于任意副本组上。
+
+## 0.14.0-Preview1 功能图
+
+<img style="width:100%; max-width:800px; max-height:1000px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Cluster/Preview1-Function.png?raw=true">

--- a/docs/zh/UserGuide/Cluster/Cluster-Setup.md
+++ b/docs/zh/UserGuide/Cluster/Cluster-Setup.md
@@ -89,7 +89,7 @@ mvn clean package -pl distribution -am -DskipTests
 | rpc\_address    | ConfigNode 在集群内部通讯使用的地址          |
 | rpc\_port    | ConfigNode 在集群内部通讯使用的端口           |
 | consensus\_port    | ConfigNode 副本组共识协议通信使用的端口         |
-| config\_nodes    | 种子 ConfigNode 地址，第一个 ConfigNode 配置自己的 address:port        |
+| target\_config\_nodes    | 种子 ConfigNode 地址，第一个 ConfigNode 配置自己的 address:port        |
 | data\_replication\_factor  | 数据副本数，DataNode 数量不应少于此数目        |
 | data\_region\_consensus\_protocol\_class |  数据副本组的共识协议 |
 | schema\_replication\_factor  | 元数据副本数，DataNode 数量不应少于此数目       |
@@ -116,6 +116,6 @@ iotdb-datanode.properties 中的重要配置如下
 | mpp\_data\_exchange\_port    | DataNode 在集群内部接收数据流使用的端口           |
 | data\_region\_consensus\_port    | DataNode 的数据副本间共识协议通信的端口           |
 | schema\_region\_consensus\_port    | DataNode 的元数据副本间共识协议通信的端口           |
-| config\_nodes    | 集群中正在运行的 ConfigNode 地址       |
+| target\_config\_nodes    | 集群中正在运行的 ConfigNode 地址       |
 
 具体参考 [DataNode配置参数](https://iotdb.apache.org/zh/UserGuide/Master/Reference/DataNode-Config-Manual.html)

--- a/docs/zh/UserGuide/Reference/ConfigNode-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/ConfigNode-Config-Manual.md
@@ -83,9 +83,9 @@ IoTDB 集群的全局配置通过 ConfigNode 配置。
 |默认值| 6667 |
 |改后生效方式|重启服务生效|
 
-* config\_nodes
+* target\_config\_nodes
 
-|名字| config\_nodes |
+|名字| target\_config\_nodes |
 |:---:|:---|
 |描述| 目标 ConfigNode 地址，ConfigNode 通过此地址加入集群 |
 |类型| String |

--- a/docs/zh/UserGuide/Reference/DataNode-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/DataNode-Config-Manual.md
@@ -229,9 +229,9 @@ IoTDB DataNode 与 Standalone 模式共用一套配置文件，均位于 IoTDB �
 |默认值| 50010 |
 |改后生效方式|重启服务生效|
 
-* config\_nodes
+* target\_config\_nodes
 
-|名字| config\_nodes |
+|名字| target\_config\_nodes |
 |:---:|:---|
 |描述| ConfigNode 地址，DataNode 启动时通过此地址加入集群 |
 |类型| String |

--- a/example/client-cpp-example/README.md
+++ b/example/client-cpp-example/README.md
@@ -34,7 +34,7 @@ You can find some files to form a complete project:
 +-- client
 |   +-- include
 |       +-- Session.h
-|       +-- TSIService.h
+|       +-- IClientRPCService.h
 |       +-- rpc_types.h
 |       +-- rpc_constants.h
 |       +-- thrift

--- a/grafana-plugin/pkg/plugin/plugin.go
+++ b/grafana-plugin/pkg/plugin/plugin.go
@@ -114,7 +114,7 @@ type queryParam struct {
 	EndTime      int64    `json:"endTime"`
 	Condition    string   `json:"condition"`
 	Control      string   `json:"control"`
-	Aggregated   string   `json:"aggregated"`
+	SqlType      string   `json:"sqlType"`
 	Paths        []string `json:"paths"`
 	AggregateFun string   `json:"aggregateFun"`
 	FillClauses  string   `json:"fillClauses"`
@@ -163,7 +163,7 @@ func (d *IoTDBDataSource) query(cxt context.Context, pCtx backend.PluginContext,
 	qp.EndTime = query.TimeRange.To.UnixNano() / 1000000
 
 	client := &http.Client{}
-	if qp.Aggregated == "Aggregation" {
+	if qp.SqlType == "SQL: Drop-down List" {
 		qp.Control = ""
 		var expressions []string = qp.Paths[len(qp.Paths)-1:]
 		var paths []string = qp.Paths[0 : len(qp.Paths)-1]

--- a/grafana-plugin/src/ConfigEditor.tsx
+++ b/grafana-plugin/src/ConfigEditor.tsx
@@ -88,6 +88,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             <FormField
               value={jsonData.password || ''}
               label="password"
+              type="password"
               placeholder="please input password"
               labelWidth={6}
               inputWidth={20}

--- a/grafana-plugin/src/QueryEditor.tsx
+++ b/grafana-plugin/src/QueryEditor.tsx
@@ -43,8 +43,8 @@ interface State {
   aggregateFun: string;
   groupBy: GroupBy;
   fillClauses: string;
-  isAggregated: boolean;
-  aggregated: string;
+  isDropDownList: boolean;
+  sqlType: string;
   shouldAdd: boolean;
 }
 
@@ -64,7 +64,7 @@ const selectElement = [
 
 const paths = [''];
 const expressions = [''];
-const selectRaw = ['Raw', 'Aggregation'];
+const selectType = ['SQL: Full Customized', 'SQL: Drop-down List'];
 const commonOption: SelectableValue<string> = { label: '*', value: '*' };
 const commonOptionDou: SelectableValue<string> = { label: '**', value: '**' };
 type Props = QueryEditorProps<DataSource, IoTDBQuery, IoTDBOptions>;
@@ -84,8 +84,8 @@ export class QueryEditor extends PureComponent<Props, State> {
       groupByLevel: '',
     },
     fillClauses: '',
-    isAggregated: false,
-    aggregated: selectRaw[0],
+    isDropDownList: false,
+    sqlType: selectType[0],
     shouldAdd: true,
   };
 
@@ -138,7 +138,7 @@ export class QueryEditor extends PureComponent<Props, State> {
     onChange({ ...query });
   };
 
-  onSelectRawChange = (event: ChangeEvent<HTMLInputElement>) => {
+  onSelectTypeChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onChange, query } = this.props;
     onChange({ ...query });
   };
@@ -176,10 +176,10 @@ export class QueryEditor extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    if (this.props.query.aggregated) {
-      this.setState({ isAggregated: this.props.query.isAggregated, aggregated: this.props.query.aggregated });
+    if (this.props.query.sqlType) {
+      this.setState({ isDropDownList: this.props.query.isDropDownList, sqlType: this.props.query.sqlType });
     } else {
-      this.props.query.aggregated = selectRaw[0];
+      this.props.query.sqlType = selectType[0];
     }
     if (this.state.options.length === 1 && this.state.options[0][0].value === '') {
       this.props.datasource.nodeQuery(['root']).then((a) => {
@@ -194,7 +194,7 @@ export class QueryEditor extends PureComponent<Props, State> {
 
   render() {
     const query = defaults(this.props.query);
-    var { expression, prefixPath, condition, control, fillClauses, aggregateFun, paths, options, aggregated, groupBy } =
+    var { expression, prefixPath, condition, control, fillClauses, aggregateFun, paths, options, sqlType, groupBy } =
       query;
     return (
       <>
@@ -204,8 +204,8 @@ export class QueryEditor extends PureComponent<Props, State> {
               <Segment
                 onChange={({ value: value = '' }) => {
                   const { onChange, query } = this.props;
-                  if (value === selectRaw[0]) {
-                    this.props.query.aggregated = selectRaw[0];
+                  if (value === selectType[0]) {
+                    this.props.query.sqlType = selectType[0];
                     this.props.query.aggregateFun = '';
                     if (this.props.query.paths) {
                       const nextTimeSeries = this.props.query.paths.filter((_, i) => i < 0);
@@ -223,40 +223,40 @@ export class QueryEditor extends PureComponent<Props, State> {
                     }
                     this.props.query.condition = '';
                     this.props.query.fillClauses = '';
-                    this.props.query.isAggregated = false;
+                    this.props.query.isDropDownList = false;
                     this.setState({
-                      isAggregated: false,
-                      aggregated: selectRaw[0],
+                      isDropDownList: false,
+                      sqlType: selectType[0],
                       shouldAdd: true,
                       aggregateFun: '',
                       fillClauses: '',
                       condition: '',
                     });
-                    onChange({ ...query, aggregated: value, isAggregated: false });
+                    onChange({ ...query, sqlType: value, isDropDownList: false });
                   } else {
-                    this.props.query.aggregated = selectRaw[1];
+                    this.props.query.sqlType = selectType[1];
                     this.props.query.expression = [''];
                     this.props.query.prefixPath = [''];
                     this.props.query.condition = '';
                     this.props.query.control = '';
-                    this.props.query.isAggregated = true;
+                    this.props.query.isDropDownList = true;
                     this.setState({
-                      isAggregated: true,
-                      aggregated: selectRaw[1],
+                      isDropDownList: true,
+                      sqlType: selectType[1],
                       expression: [''],
                       prefixPath: [''],
                       condition: '',
                       control: '',
                     });
-                    onChange({ ...query, aggregated: value, isAggregated: true });
+                    onChange({ ...query, sqlType: value, isDropDownList: true });
                   }
                 }}
-                options={selectRaw.map(toOption)}
-                value={aggregated ? aggregated : this.state.aggregated}
-                className="query-keyword width-6"
+                options={selectType.map(toOption)}
+                value={sqlType ? sqlType : this.state.sqlType}
+                className="query-keyword width-10"
               />
             </div>
-            {!this.state.isAggregated && (
+            {!this.state.isDropDownList && (
               <>
                 <div className="gf-form">
                   <QueryInlineField label={'SELECT'}>
@@ -292,7 +292,7 @@ export class QueryEditor extends PureComponent<Props, State> {
                 </div>
               </>
             )}
-            {this.state.isAggregated && (
+            {this.state.isDropDownList && (
               <>
                 <div className="gf-form">
                   <QueryInlineField label={'TIME-SERIES'}>

--- a/grafana-plugin/src/datasource.ts
+++ b/grafana-plugin/src/datasource.ts
@@ -32,7 +32,7 @@ export class DataSource extends DataSourceWithBackend<IoTDBQuery, IoTDBOptions> 
     this.username = instanceSettings.jsonData.username;
   }
   applyTemplateVariables(query: IoTDBQuery, scopedVars: ScopedVars) {
-    if (query.aggregated === 'Raw') {
+    if (query.sqlType === 'SQL: Full Customized') {
       query.expression.map(
         (_, index) => (query.expression[index] = getTemplateSrv().replace(query.expression[index], scopedVars))
       );

--- a/grafana-plugin/src/types.ts
+++ b/grafana-plugin/src/types.ts
@@ -26,8 +26,8 @@ export interface IoTDBQuery extends DataQuery {
 
   paths: string[];
   aggregateFun?: string;
-  aggregated: string;
-  isAggregated: boolean;
+  sqlType: string;
+  isDropDownList: boolean;
   fillClauses: string;
   groupBy?: GroupBy;
   limitAll?: LimitAll;

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/ConfigNodeWrapper.java
@@ -50,7 +50,7 @@ public class ConfigNodeWrapper extends AbstractNodeWrapper {
     properties.setProperty("rpc_address", super.getIp());
     properties.setProperty("rpc_port", String.valueOf(getPort()));
     properties.setProperty("consensus_port", String.valueOf(this.consensusPort));
-    properties.setProperty("config_nodes", this.targetConfigNode);
+    properties.setProperty("target_config_nodes", this.targetConfigNode);
     properties.setProperty(
         "config_node_consensus_protocol_class",
         "org.apache.iotdb.consensus.standalone.StandAloneConsensus");

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/DataNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/DataNodeWrapper.java
@@ -54,7 +54,7 @@ public class DataNodeWrapper extends AbstractNodeWrapper {
         "schema_region_consensus_port", String.valueOf(this.schemaRegionConsensusPort));
     properties.setProperty("connection_timeout_ms", "30000");
     if (this.targetConfigNode != null) {
-      properties.setProperty("config_nodes", this.targetConfigNode);
+      properties.setProperty("target_config_nodes", this.targetConfigNode);
     }
   }
 

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.rpc.IoTDBJDBCDataSet;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
 import org.apache.thrift.TException;
 
@@ -67,7 +67,7 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
       List<String> columnTypeList,
       Map<String, Integer> columnNameIndex,
       boolean ignoreTimeStamp,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       String sql,
       long queryId,
       long sessionId,
@@ -102,7 +102,7 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
       List<String> columnTypeList,
       Map<String, Integer> columnNameIndex,
       boolean ignoreTimeStamp,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       String sql,
       long queryId,
       long sessionId,

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -22,9 +22,9 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.ServerProperties;
 import org.apache.iotdb.service.rpc.thrift.TSCloseSessionReq;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSOpenSessionReq;
 import org.apache.iotdb.service.rpc.thrift.TSOpenSessionResp;
 import org.apache.iotdb.service.rpc.thrift.TSProtocolVersion;
@@ -68,7 +68,7 @@ public class IoTDBConnection implements Connection {
       TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V3;
   private static final String NOT_SUPPORT_PREPARE_CALL = "Does not support prepareCall";
   private static final String NOT_SUPPORT_PREPARE_STATEMENT = "Does not support prepareStatement";
-  private TSIService.Iface client = null;
+  private IClientRPCService.Iface client = null;
   private long sessionId = -1;
   private IoTDBConnectionParams params;
   private boolean isClosed = true;
@@ -111,9 +111,9 @@ public class IoTDBConnection implements Connection {
     this.zoneId = ZoneId.of(params.getTimeZone());
     openTransport();
     if (Config.rpcThriftCompressionEnable) {
-      setClient(new TSIService.Client(new TCompactProtocol(transport)));
+      setClient(new IClientRPCService.Client(new TCompactProtocol(transport)));
     } else {
-      setClient(new TSIService.Client(new TBinaryProtocol(transport)));
+      setClient(new IClientRPCService.Client(new TBinaryProtocol(transport)));
     }
     // open client session
     openSession();
@@ -454,7 +454,7 @@ public class IoTDBConnection implements Connection {
     throw new SQLException("Does not support setSavepoint");
   }
 
-  public TSIService.Iface getClient() {
+  public IClientRPCService.Iface getClient() {
     return client;
   }
 
@@ -462,7 +462,7 @@ public class IoTDBConnection implements Connection {
     return sessionId;
   }
 
-  public void setClient(TSIService.Iface client) {
+  public void setClient(IClientRPCService.Iface client) {
     this.client = client;
   }
 
@@ -536,9 +536,9 @@ public class IoTDBConnection implements Connection {
           transport.close();
           openTransport();
           if (Config.rpcThriftCompressionEnable) {
-            setClient(new TSIService.Client(new TCompactProtocol(transport)));
+            setClient(new IClientRPCService.Client(new TCompactProtocol(transport)));
           } else {
-            setClient(new TSIService.Client(new TBinaryProtocol(transport)));
+            setClient(new IClientRPCService.Client(new TBinaryProtocol(transport)));
           }
           openSession();
           setClient(RpcUtils.newSynchronizedClient(getClient()));

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
@@ -20,9 +20,9 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -57,7 +57,7 @@ import java.util.TreeMap;
 public class IoTDBDatabaseMetadata implements DatabaseMetaData {
 
   private IoTDBConnection connection;
-  private TSIService.Iface client;
+  private IClientRPCService.Iface client;
   private static final Logger logger = LoggerFactory.getLogger(IoTDBDatabaseMetadata.class);
   private static final String METHOD_NOT_SUPPORTED_STRING = "Method not supported";
   // when running the program in IDE, we can not get the version info using
@@ -70,7 +70,8 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
   private WatermarkEncoder groupedLSBWatermarkEncoder;
   private static String sqlKeywordsThatArentSQL92;
 
-  IoTDBDatabaseMetadata(IoTDBConnection connection, TSIService.Iface client, long sessionId) {
+  IoTDBDatabaseMetadata(
+      IoTDBConnection connection, IClientRPCService.Iface client, long sessionId) {
     this.connection = connection;
     this.client = client;
     this.sessionId = sessionId;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.service.rpc.thrift.TSTracingInfo;
 
@@ -42,7 +42,7 @@ public class IoTDBJDBCResultSet extends AbstractIoTDBJDBCResultSet {
       List<String> columnTypeList,
       Map<String, Integer> columnNameIndex,
       boolean ignoreTimeStamp,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       String sql,
       long queryId,
       long sessionId,
@@ -83,7 +83,7 @@ public class IoTDBJDBCResultSet extends AbstractIoTDBJDBCResultSet {
       List<String> columnTypeList,
       Map<String, Integer> columnNameIndex,
       boolean ignoreTimeStamp,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       String sql,
       long queryId,
       long sessionId,

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignJDBCResultSet.java
@@ -21,9 +21,9 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryNonAlignDataSet;
 import org.apache.iotdb.service.rpc.thrift.TSTracingInfo;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
@@ -61,7 +61,7 @@ public class IoTDBNonAlignJDBCResultSet extends AbstractIoTDBJDBCResultSet {
       List<String> columnTypeList,
       Map<String, Integer> columnNameIndex,
       boolean ignoreTimeStamp,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       String sql,
       long queryId,
       long sessionId,

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBPreparedStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBPreparedStatement.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.jdbc;
 
-import org.apache.iotdb.service.rpc.thrift.TSIService.Iface;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
 import org.apache.iotdb.tsfile.utils.Binary;
 
 import org.apache.thrift.TException;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -23,12 +23,12 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSCancelOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteBatchStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.service.rpc.thrift.TSQueryNonAlignDataSet;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
@@ -63,7 +63,7 @@ public class IoTDBStatement implements Statement {
    */
   private int queryTimeout = -1;
 
-  protected TSIService.Iface client;
+  protected IClientRPCService.Iface client;
   private List<String> batchSQLList;
   private static final String NOT_SUPPORT_EXECUTE = "Not support execute";
   private static final String NOT_SUPPORT_EXECUTE_UPDATE = "Not support executeUpdate";
@@ -83,7 +83,7 @@ public class IoTDBStatement implements Statement {
   /** Constructor of IoTDBStatement. */
   IoTDBStatement(
       IoTDBConnection connection,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       int fetchSize,
       ZoneId zoneId,
@@ -102,7 +102,7 @@ public class IoTDBStatement implements Statement {
   // only for test
   IoTDBStatement(
       IoTDBConnection connection,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       ZoneId zoneId,
       int seconds,
@@ -117,14 +117,15 @@ public class IoTDBStatement implements Statement {
     this.stmtId = statementId;
   }
 
-  IoTDBStatement(IoTDBConnection connection, TSIService.Iface client, long sessionId, ZoneId zoneId)
+  IoTDBStatement(
+      IoTDBConnection connection, IClientRPCService.Iface client, long sessionId, ZoneId zoneId)
       throws SQLException {
     this(connection, client, sessionId, Config.DEFAULT_FETCH_SIZE, zoneId, 0);
   }
 
   IoTDBStatement(
       IoTDBConnection connection,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       ZoneId zoneId,
       int seconds)

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/BatchTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/BatchTest.java
@@ -21,8 +21,8 @@ package org.apache.iotdb.jdbc;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteBatchStatementReq;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 
 import org.apache.thrift.TException;
 import org.junit.After;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 public class BatchTest {
 
   @Mock private IoTDBConnection connection;
-  @Mock private TSIService.Iface client;
+  @Mock private IClientRPCService.Iface client;
   private long sessionId;
   @Mock private IoTDBStatement statement;
   private TSStatus errorStatus = RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR);

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
@@ -20,9 +20,9 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.ServerProperties;
 import org.apache.iotdb.service.rpc.thrift.TSGetTimeZoneResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
 
 import org.apache.thrift.TException;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 
 public class IoTDBConnectionTest {
 
-  @Mock private TSIService.Iface client;
+  @Mock private IClientRPCService.Iface client;
 
   private IoTDBConnection connection = new IoTDBConnection();
   private TSStatus successStatus = RpcUtils.SUCCESS_STATUS;

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadataTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadataTest.java
@@ -21,11 +21,11 @@ package org.apache.iotdb.jdbc;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.ServerProperties;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteBatchStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 
 import org.apache.thrift.TException;
 import org.junit.Assert;
@@ -55,7 +55,7 @@ public class IoTDBDatabaseMetadataTest {
   private long sessionId;
   private TSStatus resp;
   @Mock private IoTDBConnection connection;
-  @Mock private TSIService.Iface client;
+  @Mock private IClientRPCService.Iface client;
   @Mock private Statement statement;
   @Mock private DatabaseMetaData databaseMetaData;
   @Mock private TSStatus successStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
@@ -27,7 +28,6 @@ import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
@@ -109,7 +109,7 @@ public class IoTDBJDBCResultSetTest {
   private long queryId;
   private long sessionId;
   @Mock private IoTDBConnection connection;
-  @Mock private TSIService.Iface client;
+  @Mock private IClientRPCService.Iface client;
   @Mock private Statement statement;
   @Mock private TSFetchMetadataResp fetchMetadataResp;
   @Mock private TSFetchResultsResp fetchResultsResp;

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBPreparedStatementTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBPreparedStatementTest.java
@@ -20,9 +20,9 @@ package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService.Iface;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBStatementTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBStatementTest.java
@@ -19,9 +19,9 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService.Iface;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeIServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeIServiceClient.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.AsyncBaseClientFactory;
 import org.apache.iotdb.commons.client.ClientFactoryProperty;
 import org.apache.iotdb.commons.client.ClientManager;
-import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
+import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 
 import org.apache.commons.pool2.PooledObject;
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-public class AsyncConfigNodeIServiceClient extends ConfigIService.AsyncClient {
+public class AsyncConfigNodeIServiceClient extends IConfigNodeRPCService.AsyncClient {
 
   private static final Logger logger = LoggerFactory.getLogger(AsyncConfigNodeIServiceClient.class);
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeInternalServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeInternalServiceClient.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.commons.client.AsyncBaseClientFactory;
 import org.apache.iotdb.commons.client.ClientFactoryProperty;
 import org.apache.iotdb.commons.client.ClientManager;
 import org.apache.iotdb.commons.utils.TestOnly;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 
 import org.apache.commons.pool2.PooledObject;
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-public class AsyncDataNodeInternalServiceClient extends InternalService.AsyncClient {
+public class AsyncDataNodeInternalServiceClient extends IDataNodeRPCService.AsyncClient {
 
   private static final Logger logger =
       LoggerFactory.getLogger(AsyncDataNodeInternalServiceClient.class);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncConfigNodeIServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncConfigNodeIServiceClient.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.BaseClientFactory;
 import org.apache.iotdb.commons.client.ClientFactoryProperty;
 import org.apache.iotdb.commons.client.ClientManager;
-import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
+import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TimeoutChangeableTransport;
@@ -37,7 +37,7 @@ import org.apache.thrift.transport.TTransportException;
 import java.lang.reflect.Constructor;
 import java.net.SocketException;
 
-public class SyncConfigNodeIServiceClient extends ConfigIService.Client
+public class SyncConfigNodeIServiceClient extends IConfigNodeRPCService.Client
     implements SyncThriftClient, AutoCloseable {
 
   private final TEndPoint endPoint;

--- a/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncDataNodeInternalServiceClient.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncDataNodeInternalServiceClient.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.commons.client.BaseClientFactory;
 import org.apache.iotdb.commons.client.ClientFactoryProperty;
 import org.apache.iotdb.commons.client.ClientManager;
 import org.apache.iotdb.commons.utils.TestOnly;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TimeoutChangeableTransport;
@@ -38,7 +38,7 @@ import org.apache.thrift.transport.TTransportException;
 import java.lang.reflect.Constructor;
 import java.net.SocketException;
 
-public class SyncDataNodeInternalServiceClient extends InternalService.Client
+public class SyncDataNodeInternalServiceClient extends IDataNodeRPCService.Client
     implements SyncThriftClient, AutoCloseable {
 
   private final TEndPoint endPoint;

--- a/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.client.mock.MockInternalRPCService;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.exception.StartupException;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 
 import org.apache.commons.pool2.KeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
@@ -47,7 +47,7 @@ public class ClientManagerTest {
   @Before
   public void setUp() throws StartupException {
     service = new MockInternalRPCService(endPoint);
-    service.initSyncedServiceImpl(mock(InternalService.Iface.class));
+    service.initSyncedServiceImpl(mock(IDataNodeRPCService.Iface.class));
     service.start();
   }
 

--- a/node-commons/src/test/java/org/apache/iotdb/commons/client/mock/MockInternalRPCService.java
+++ b/node-commons/src/test/java/org/apache/iotdb/commons/client/mock/MockInternalRPCService.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.commons.exception.runtime.RPCServiceException;
 import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 
 import org.apache.thrift.server.TServerEventHandler;
 
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
 public class MockInternalRPCService extends ThriftService implements MockInternalRPCServiceMBean {
 
   private final TEndPoint thisNode;
-  private InternalService.Iface mockedProcessor;
+  private IDataNodeRPCService.Iface mockedProcessor;
 
   public MockInternalRPCService(TEndPoint thisNode) {
     this.thisNode = thisNode;
@@ -48,7 +48,7 @@ public class MockInternalRPCService extends ThriftService implements MockInterna
 
   @Override
   public void initSyncedServiceImpl(Object mockedProcessor) {
-    this.mockedProcessor = (InternalService.Iface) mockedProcessor;
+    this.mockedProcessor = (IDataNodeRPCService.Iface) mockedProcessor;
     super.mbeanName =
         String.format(
             "%s:%s=%s", this.getClass().getPackage(), IoTDBConstant.JMX_TYPE, getID().getJmxName());
@@ -57,7 +57,7 @@ public class MockInternalRPCService extends ThriftService implements MockInterna
 
   @Override
   public void initTProcessor() {
-    processor = new InternalService.Processor<>(mockedProcessor);
+    processor = new IDataNodeRPCService.Processor<>(mockedProcessor);
   }
 
   @Override

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -1031,7 +1031,7 @@ timestamp_precision=ms
 # cache size for partition.
 # This cache is used to improve partition fetch from config node.
 # Datatype: int
-# partition_cache_size=100000
+# partition_cache_size=0
 
 ####################
 ### Schema File Configuration

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -59,10 +59,13 @@ data_region_consensus_port=40010
 # port for consensus's communication for schema region between cluster nodes.
 schema_region_consensus_port=50010
 
-# comma-separated {IP/DOMAIN}:internal_port pairs
-# Data nodes store config nodes ip and port to communicate with config nodes.
-# Several nodes will be picked randomly to send the request, the number of nodes
-# picked depends on the number of retries.
+# Used for connecting to the ConfigNodeGroup
+# Format: ip:port
+# where the ip should be consistent with the target ConfigNode's confignode_rpc_address,
+# and the port should be consistent with the target ConfigNode's confignode_rpc_port.
+# When successfully connecting to the ConfigNodeGroup, DataNode will get all online
+# config nodes and store them in memory.
+# Datatype: String
 config_nodes=127.0.0.1:22277
 
 # Datatype: boolean

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -598,6 +598,10 @@ timestamp_precision=ms
 # Datatype: int
 # query_timeout_threshold=60000
 
+# The maximum allowed concurrently executing queries
+# Datatype: int
+# max_allowed_concurrent_queries=1000
+
 # The number of sub compaction threads to be set up to perform compaction.
 # Currently only works for nonAligned data in cross space compaction and unseq inner space compaction.
 # Set to 1 when less than or equal to 0.

--- a/server/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/server/src/assembly/resources/conf/iotdb-datanode.properties
@@ -59,14 +59,14 @@ data_region_consensus_port=40010
 # port for consensus's communication for schema region between cluster nodes.
 schema_region_consensus_port=50010
 
-# Used for connecting to the ConfigNodeGroup
+# At least one running ConfigNode should be set for joining the cluster
 # Format: ip:port
 # where the ip should be consistent with the target ConfigNode's confignode_rpc_address,
 # and the port should be consistent with the target ConfigNode's confignode_rpc_port.
 # When successfully connecting to the ConfigNodeGroup, DataNode will get all online
 # config nodes and store them in memory.
 # Datatype: String
-config_nodes=127.0.0.1:22277
+target_config_nodes=127.0.0.1:22277
 
 # Datatype: boolean
 # rpc_thrift_compression_enable=false

--- a/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/client/ConfigNodeClient.java
@@ -30,7 +30,7 @@ import org.apache.iotdb.commons.client.ClientPoolProperty;
 import org.apache.iotdb.commons.client.sync.SyncThriftClient;
 import org.apache.iotdb.commons.client.sync.SyncThriftClientWithErrorHandler;
 import org.apache.iotdb.commons.consensus.PartitionRegionId;
-import org.apache.iotdb.confignode.rpc.thrift.ConfigIService;
+import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.confignode.rpc.thrift.TAuthorizerReq;
 import org.apache.iotdb.confignode.rpc.thrift.TAuthorizerResp;
 import org.apache.iotdb.confignode.rpc.thrift.TCheckUserPrivilegesReq;
@@ -82,7 +82,8 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ConfigNodeClient implements ConfigIService.Iface, SyncThriftClient, AutoCloseable {
+public class ConfigNodeClient
+    implements IConfigNodeRPCService.Iface, SyncThriftClient, AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(ConfigNodeClient.class);
 
   private static final int RETRY_NUM = 5;
@@ -92,7 +93,7 @@ public class ConfigNodeClient implements ConfigIService.Iface, SyncThriftClient,
 
   private long connectionTimeout = ClientPoolProperty.DefaultProperty.WAIT_CLIENT_TIMEOUT_MS;
 
-  private ConfigIService.Iface client;
+  private IConfigNodeRPCService.Iface client;
 
   private TTransport transport;
 
@@ -152,7 +153,7 @@ public class ConfigNodeClient implements ConfigIService.Iface, SyncThriftClient,
       throw new TException(e);
     }
 
-    client = new ConfigIService.Client(protocolFactory.getProtocol(transport));
+    client = new IConfigNodeRPCService.Client(protocolFactory.getProtocol(transport));
   }
 
   private void reconnect() throws TException {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -296,6 +296,9 @@ public class IoTDBConfig {
   /** How many threads can concurrently execute query statement. When <= 0, use CPU core number. */
   private int concurrentQueryThread = 16;
 
+  /** How many queries can be concurrently executed. When <= 0, use 1000. */
+  private int maxAllowedConcurrentQueries = 1000;
+
   /**
    * How many threads can concurrently read data for raw data query. When <= 0, use CPU core number.
    */
@@ -1322,6 +1325,14 @@ public class IoTDBConfig {
 
   public void setConcurrentQueryThread(int concurrentQueryThread) {
     this.concurrentQueryThread = concurrentQueryThread;
+  }
+
+  public int getMaxAllowedConcurrentQueries() {
+    return maxAllowedConcurrentQueries;
+  }
+
+  public void setMaxAllowedConcurrentQueries(int maxAllowedConcurrentQueries) {
+    this.maxAllowedConcurrentQueries = maxAllowedConcurrentQueries;
   }
 
   public int getConcurrentSubRawQueryThread() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -840,7 +840,7 @@ public class IoTDBConfig {
   private int schemaRegionConsensusPort = 50010;
 
   /** Ip and port of config nodes. */
-  private List<TEndPoint> configNodeList =
+  private List<TEndPoint> targetConfigNodeList =
       Collections.singletonList(new TEndPoint("127.0.0.1", 22277));
 
   /** The max time of data node waiting to join into the cluster */
@@ -2736,12 +2736,12 @@ public class IoTDBConfig {
     this.schemaRegionConsensusPort = schemaRegionConsensusPort;
   }
 
-  public List<TEndPoint> getConfigNodeList() {
-    return configNodeList;
+  public List<TEndPoint> getTargetConfigNodeList() {
+    return targetConfigNodeList;
   }
 
-  public void setConfigNodeList(List<TEndPoint> configNodeList) {
-    this.configNodeList = configNodeList;
+  public void setTargetConfigNodeList(List<TEndPoint> targetConfigNodeList) {
+    this.targetConfigNodeList = targetConfigNodeList;
   }
 
   public long getJoinClusterTimeOutMs() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -896,7 +896,7 @@ public class IoTDBConfig {
    * Cache size of partition cache in {@link
    * org.apache.iotdb.db.mpp.plan.analyze.ClusterPartitionFetcher}
    */
-  private int partitionCacheSize = 100000;
+  private int partitionCacheSize = 0;
 
   /** Cache size of user and role */
   private int authorCacheSize = 100;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1645,7 +1645,7 @@ public class IoTDBDescriptor {
   }
 
   public void loadClusterProps(Properties properties) {
-    String configNodeUrls = properties.getProperty("config_nodes");
+    String configNodeUrls = properties.getProperty("target_config_nodes");
     if (configNodeUrls != null) {
       try {
         conf.setTargetConfigNodeList(NodeUrlUtils.parseTEndPointUrls(configNodeUrls));

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -476,6 +476,16 @@ public class IoTDBDescriptor {
         conf.setConcurrentQueryThread(Runtime.getRuntime().availableProcessors());
       }
 
+      conf.setMaxAllowedConcurrentQueries(
+          Integer.parseInt(
+              properties.getProperty(
+                  "max_allowed_concurrent_queries",
+                  Integer.toString(conf.getConcurrentQueryThread()))));
+
+      if (conf.getMaxAllowedConcurrentQueries() <= 0) {
+        conf.setMaxAllowedConcurrentQueries(1000);
+      }
+
       conf.setConcurrentSubRawQueryThread(
           Integer.parseInt(
               properties.getProperty(

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -935,7 +935,7 @@ public class IoTDBDescriptor {
       conf.setInternalIp(InetAddress.getByName(conf.getInternalIp()).getHostAddress());
     }
 
-    for (TEndPoint configNode : conf.getConfigNodeList()) {
+    for (TEndPoint configNode : conf.getTargetConfigNodeList()) {
       boolean isInvalidNodeIp = InetAddresses.isInetAddress(configNode.ip);
       if (!isInvalidNodeIp) {
         String newNodeIP = InetAddress.getByName(configNode.ip).getHostAddress();
@@ -947,7 +947,7 @@ public class IoTDBDescriptor {
         "after replace, the rpcIP={}, internalIP={}, configNodeUrls={}",
         conf.getRpcAddress(),
         conf.getInternalIp(),
-        conf.getConfigNodeList());
+        conf.getTargetConfigNodeList());
   }
 
   private void loadWALProps(Properties properties) {
@@ -1648,7 +1648,7 @@ public class IoTDBDescriptor {
     String configNodeUrls = properties.getProperty("config_nodes");
     if (configNodeUrls != null) {
       try {
-        conf.setConfigNodeList(NodeUrlUtils.parseTEndPointUrls(configNodeUrls));
+        conf.setTargetConfigNodeList(NodeUrlUtils.parseTEndPointUrls(configNodeUrls));
       } catch (BadNodeUrlException e) {
         logger.error(
             "Config nodes are set in wrong format, please set them like 0.0.0.0:22277,0.0.0.0:22281");

--- a/server/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -38,56 +38,59 @@ import org.apache.iotdb.db.engine.StorageEngineV2;
  * dataRegion's reading and writing
  */
 public class DataRegionConsensusImpl {
+  private static final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+
+  private static IConsensus INSTANCE = null;
 
   private DataRegionConsensusImpl() {}
 
+  // need to create instance before calling this method
   public static IConsensus getInstance() {
-    return DataRegionConsensusImplHolder.INSTANCE;
+    return INSTANCE;
   }
 
-  private static class DataRegionConsensusImplHolder {
-
-    private static final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
-    private static final IConsensus INSTANCE =
-        ConsensusFactory.getConsensusImpl(
-                conf.getDataRegionConsensusProtocolClass(),
-                ConsensusConfig.newBuilder()
-                    .setThisNode(
-                        new TEndPoint(conf.getInternalIp(), conf.getDataRegionConsensusPort()))
-                    .setStorageDir(conf.getDataRegionConsensusDir())
-                    .setMultiLeaderConfig(
-                        MultiLeaderConfig.newBuilder()
-                            .setRpc(
-                                RPC.newBuilder()
-                                    .setConnectionTimeoutInMs(conf.getConnectionTimeoutInMS())
-                                    .setRpcMaxConcurrentClientNum(
-                                        conf.getRpcMaxConcurrentClientNum())
-                                    .setRpcThriftCompressionEnabled(
-                                        conf.isRpcThriftCompressionEnable())
-                                    .setSelectorNumOfClientManager(
-                                        conf.getSelectorNumOfClientManager())
-                                    .setThriftServerAwaitTimeForStopService(
-                                        conf.getThriftServerAwaitTimeForStopService())
-                                    .build())
-                            .build())
-                    .setRatisConfig(
-                        RatisConfig.newBuilder()
-                            // An empty log is committed after each restart, even if no data is
-                            // written. This setting ensures that compaction work is not discarded
-                            // even if there are frequent restarts
-                            .setSnapshot(Snapshot.newBuilder().setCreationGap(1).build())
-                            .build())
-                    .build(),
-                gid ->
-                    new DataRegionStateMachine(
-                        StorageEngineV2.getInstance().getDataRegion((DataRegionId) gid)))
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            ConsensusFactory.CONSTRUCT_FAILED_MSG,
-                            conf.getDataRegionConsensusProtocolClass())));
-
-    private DataRegionConsensusImplHolder() {}
+  public static synchronized IConsensus setupAndGetInstance() {
+    if (INSTANCE == null) {
+      INSTANCE =
+          ConsensusFactory.getConsensusImpl(
+                  conf.getDataRegionConsensusProtocolClass(),
+                  ConsensusConfig.newBuilder()
+                      .setThisNode(
+                          new TEndPoint(conf.getInternalIp(), conf.getDataRegionConsensusPort()))
+                      .setStorageDir(conf.getDataRegionConsensusDir())
+                      .setMultiLeaderConfig(
+                          MultiLeaderConfig.newBuilder()
+                              .setRpc(
+                                  RPC.newBuilder()
+                                      .setConnectionTimeoutInMs(conf.getConnectionTimeoutInMS())
+                                      .setRpcMaxConcurrentClientNum(
+                                          conf.getRpcMaxConcurrentClientNum())
+                                      .setRpcThriftCompressionEnabled(
+                                          conf.isRpcThriftCompressionEnable())
+                                      .setSelectorNumOfClientManager(
+                                          conf.getSelectorNumOfClientManager())
+                                      .setThriftServerAwaitTimeForStopService(
+                                          conf.getThriftServerAwaitTimeForStopService())
+                                      .build())
+                              .build())
+                      .setRatisConfig(
+                          RatisConfig.newBuilder()
+                              // An empty log is committed after each restart, even if no data is
+                              // written. This setting ensures that compaction work is not discarded
+                              // even if there are frequent restarts
+                              .setSnapshot(Snapshot.newBuilder().setCreationGap(1).build())
+                              .build())
+                      .build(),
+                  gid ->
+                      new DataRegionStateMachine(
+                          StorageEngineV2.getInstance().getDataRegion((DataRegionId) gid)))
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          String.format(
+                              ConsensusFactory.CONSTRUCT_FAILED_MSG,
+                              conf.getDataRegionConsensusProtocolClass())));
+    }
+    return INSTANCE;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -35,33 +35,37 @@ import org.apache.iotdb.db.metadata.schemaregion.SchemaEngine;
  */
 public class SchemaRegionConsensusImpl {
 
+  private static final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+
+  private static IConsensus INSTANCE = null;
+
   private SchemaRegionConsensusImpl() {}
 
+  // need to create instance before calling this method
   public static IConsensus getInstance() {
-    return SchemaRegionConsensusImplHolder.INSTANCE;
+    return INSTANCE;
   }
 
-  private static class SchemaRegionConsensusImplHolder {
-
-    private static final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
-    private static final IConsensus INSTANCE =
-        ConsensusFactory.getConsensusImpl(
-                conf.getSchemaRegionConsensusProtocolClass(),
-                ConsensusConfig.newBuilder()
-                    .setThisNode(
-                        new TEndPoint(conf.getInternalIp(), conf.getSchemaRegionConsensusPort()))
-                    .setStorageDir(conf.getSchemaRegionConsensusDir())
-                    .build(),
-                gid ->
-                    new SchemaRegionStateMachine(
-                        SchemaEngine.getInstance().getSchemaRegion((SchemaRegionId) gid)))
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            ConsensusFactory.CONSTRUCT_FAILED_MSG,
-                            conf.getSchemaRegionConsensusProtocolClass())));
-
-    private SchemaRegionConsensusImplHolder() {}
+  public static synchronized IConsensus setupAndGetInstance() {
+    if (INSTANCE == null) {
+      INSTANCE =
+          ConsensusFactory.getConsensusImpl(
+                  conf.getSchemaRegionConsensusProtocolClass(),
+                  ConsensusConfig.newBuilder()
+                      .setThisNode(
+                          new TEndPoint(conf.getInternalIp(), conf.getSchemaRegionConsensusPort()))
+                      .setStorageDir(conf.getSchemaRegionConsensusDir())
+                      .build(),
+                  gid ->
+                      new SchemaRegionStateMachine(
+                          SchemaEngine.getInstance().getSchemaRegion((SchemaRegionId) gid)))
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          String.format(
+                              ConsensusFactory.CONSTRUCT_FAILED_MSG,
+                              conf.getSchemaRegionConsensusProtocolClass())));
+    }
+    return INSTANCE;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/schedule/DriverScheduler.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.service.IService;
 import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.QueryId;
 import org.apache.iotdb.db.mpp.execution.driver.IDriver;
@@ -63,11 +64,14 @@ public class DriverScheduler implements IDriverScheduler, IService {
   private final Set<DriverTask> blockedTasks;
   private final Map<QueryId, Set<DriverTask>> queryMap;
   private final ITaskScheduler scheduler;
-  private IMPPDataExchangeManager blockManager; // TODO: init with real IMPPDataExchangeManager
+  private IMPPDataExchangeManager blockManager;
 
-  private static final int MAX_CAPACITY = 1000; // TODO: load from config files
-  private static final int WORKER_THREAD_NUM = 4; // TODO: load from config files
-  private static final int QUERY_TIMEOUT_MS = 60_000; // TODO: load from config files or requests
+  private static final int MAX_CAPACITY =
+      IoTDBDescriptor.getInstance().getConfig().getMaxAllowedConcurrentQueries();
+  private static final int WORKER_THREAD_NUM =
+      IoTDBDescriptor.getInstance().getConfig().getConcurrentQueryThread();
+  private static final int QUERY_TIMEOUT_MS =
+      IoTDBDescriptor.getInstance().getConfig().getQueryTimeoutThreshold();
   private final ThreadGroup workerGroups;
   private final List<AbstractDriverThread> threads;
 

--- a/server/src/main/java/org/apache/iotdb/db/service/ClientRPCService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/ClientRPCService.java
@@ -27,14 +27,14 @@ import org.apache.iotdb.commons.service.ThriftServiceThread;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.thrift.handler.InternalServiceThriftHandler;
-import org.apache.iotdb.db.service.thrift.impl.InternalServiceImpl;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService.Processor;
+import org.apache.iotdb.db.service.thrift.impl.DataNodeRPCServiceImpl;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService.Processor;
 
-public class InternalService extends ThriftService implements InternalServiceMBean {
+public class ClientRPCService extends ThriftService implements ClientRPCServiceMBean {
 
-  private InternalServiceImpl impl;
+  private DataNodeRPCServiceImpl impl;
 
-  private InternalService() {}
+  private ClientRPCService() {}
 
   @Override
   public ServiceType getID() {
@@ -44,7 +44,7 @@ public class InternalService extends ThriftService implements InternalServiceMBe
   @Override
   public void initTProcessor()
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
-    impl = new InternalServiceImpl();
+    impl = new DataNodeRPCServiceImpl();
     initSyncedServiceImpl(null);
     processor = new Processor<>(impl);
   }
@@ -82,13 +82,13 @@ public class InternalService extends ThriftService implements InternalServiceMBe
     return IoTDBDescriptor.getInstance().getConfig().getInternalPort();
   }
 
-  private static class InternalServiceHolder {
-    private static final InternalService INSTANCE = new InternalService();
+  private static class ClientRPCServiceHolder {
+    private static final ClientRPCService INSTANCE = new ClientRPCService();
 
-    private InternalServiceHolder() {}
+    private ClientRPCServiceHolder() {}
   }
 
-  public static InternalService getInstance() {
-    return InternalService.InternalServiceHolder.INSTANCE;
+  public static ClientRPCService getInstance() {
+    return ClientRPCServiceHolder.INSTANCE;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/ClientRPCServiceMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/ClientRPCServiceMBean.java
@@ -19,4 +19,4 @@
 
 package org.apache.iotdb.db.service;
 
-public interface InternalServiceMBean {}
+public interface ClientRPCServiceMBean {}

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -276,8 +276,8 @@ public class DataNode implements DataNodeMBean {
 
     try {
       // TODO: Start consensus layer in some where else
-      SchemaRegionConsensusImpl.getInstance().start();
-      DataRegionConsensusImpl.getInstance().start();
+      SchemaRegionConsensusImpl.setupAndGetInstance().start();
+      DataRegionConsensusImpl.setupAndGetInstance().start();
     } catch (IOException e) {
       throw new StartupException(e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -60,7 +60,7 @@ import org.apache.iotdb.db.protocol.rest.RestService;
 import org.apache.iotdb.db.service.basic.ServiceProvider;
 import org.apache.iotdb.db.service.basic.StandaloneServiceProvider;
 import org.apache.iotdb.db.service.metrics.MetricsService;
-import org.apache.iotdb.db.service.thrift.impl.DataNodeTSIServiceImpl;
+import org.apache.iotdb.db.service.thrift.impl.DataNodeTSServiceImpl;
 import org.apache.iotdb.db.sync.receiver.ReceiverService;
 import org.apache.iotdb.db.sync.sender.service.SenderService;
 import org.apache.iotdb.db.wal.WALManager;
@@ -163,7 +163,7 @@ public class DataNode implements DataNodeMBean {
 
     // start InternalService first so that it can respond to configNode's heartbeat before joining
     // cluster
-    registerManager.register(InternalService.getInstance());
+    registerManager.register(ClientRPCService.getInstance());
   }
 
   /** register DataNode with ConfigNode */
@@ -396,7 +396,7 @@ public class DataNode implements DataNodeMBean {
     // init rpc service
     IoTDBDescriptor.getInstance()
         .getConfig()
-        .setRpcImplClassName(DataNodeTSIServiceImpl.class.getName());
+        .setRpcImplClassName(DataNodeTSServiceImpl.class.getName());
     if (IoTDBDescriptor.getInstance().getConfig().isEnableRpcService()) {
       registerManager.register(RPCService.getInstance());
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -171,7 +171,7 @@ public class DataNode implements DataNodeMBean {
     int retry = DEFAULT_JOIN_RETRY;
 
     ConfigNodeInfo.getInstance()
-        .updateConfigNodeList(IoTDBDescriptor.getInstance().getConfig().getConfigNodeList());
+        .updateConfigNodeList(IoTDBDescriptor.getInstance().getConfig().getTargetConfigNodeList());
     while (retry > 0) {
       logger.info("start registering to the cluster.");
       try (ConfigNodeClient configNodeClient = new ConfigNodeClient()) {
@@ -346,8 +346,6 @@ public class DataNode implements DataNodeMBean {
   private void activateCurrentDataNode() throws StartupException {
     int retry = DEFAULT_JOIN_RETRY;
 
-    ConfigNodeInfo.getInstance()
-        .updateConfigNodeList(IoTDBDescriptor.getInstance().getConfig().getConfigNodeList());
     while (retry > 0) {
       logger.info("start joining the cluster.");
       try (ConfigNodeClient configNodeClient = new ConfigNodeClient()) {

--- a/server/src/main/java/org/apache/iotdb/db/service/NewIoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/NewIoTDB.java
@@ -48,7 +48,7 @@ import org.apache.iotdb.db.protocol.rest.RestService;
 import org.apache.iotdb.db.rescon.PrimitiveArrayManager;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.service.metrics.MetricsService;
-import org.apache.iotdb.db.service.thrift.impl.DataNodeTSIServiceImpl;
+import org.apache.iotdb.db.service.thrift.impl.DataNodeTSServiceImpl;
 import org.apache.iotdb.db.sync.receiver.ReceiverService;
 import org.apache.iotdb.db.sync.sender.service.SenderService;
 import org.apache.iotdb.db.wal.WALManager;
@@ -129,7 +129,7 @@ public class NewIoTDB implements NewIoTDBMBean {
     // init rpc service
     IoTDBDescriptor.getInstance()
         .getConfig()
-        .setRpcImplClassName(DataNodeTSIServiceImpl.class.getName());
+        .setRpcImplClassName(DataNodeTSServiceImpl.class.getName());
 
     registerManager.register(MetricsService.getInstance());
     logger.info("recover the schema...");
@@ -144,7 +144,7 @@ public class NewIoTDB implements NewIoTDBMBean {
 
     registerManager.register(StorageEngineV2.getInstance());
     registerManager.register(MPPDataExchangeService.getInstance());
-    registerManager.register(InternalService.getInstance());
+    registerManager.register(ClientRPCService.getInstance());
     registerManager.register(DriverScheduler.getInstance());
 
     registerManager.register(TemporaryQueryDataFileService.getInstance());

--- a/server/src/main/java/org/apache/iotdb/db/service/RPCService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/RPCService.java
@@ -29,7 +29,7 @@ import org.apache.iotdb.db.service.thrift.ProcessorWithMetrics;
 import org.apache.iotdb.db.service.thrift.handler.RPCServiceThriftHandler;
 import org.apache.iotdb.db.service.thrift.impl.TSIEventHandler;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
-import org.apache.iotdb.service.rpc.thrift.TSIService.Processor;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Processor;
 
 import java.lang.reflect.InvocationTargetException;
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/ProcessorWithMetrics.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/ProcessorWithMetrics.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.db.service.metrics.MetricsService;
 import org.apache.iotdb.db.service.metrics.enums.Metric;
 import org.apache.iotdb.db.service.metrics.enums.Tag;
 import org.apache.iotdb.metrics.utils.MetricLevel;
-import org.apache.iotdb.service.rpc.thrift.TSIService.Iface;
-import org.apache.iotdb.service.rpc.thrift.TSIService.Processor;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Processor;
 
 import org.apache.thrift.ProcessFunction;
 import org.apache.thrift.TApplicationException;

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeRPCServiceImpl.java
@@ -340,22 +340,27 @@ public class DataNodeRPCServiceImpl implements IDataNodeRPCService.Iface {
 
   private Map<TConsensusGroupId, Boolean> getJudgedLeaders() {
     Map<TConsensusGroupId, Boolean> result = new HashMap<>();
-    DataRegionConsensusImpl.getInstance()
-        .getAllConsensusGroupIds()
-        .forEach(
-            groupId -> {
-              result.put(
-                  groupId.convertToTConsensusGroupId(),
-                  DataRegionConsensusImpl.getInstance().isLeader(groupId));
-            });
-    SchemaRegionConsensusImpl.getInstance()
-        .getAllConsensusGroupIds()
-        .forEach(
-            groupId -> {
-              result.put(
-                  groupId.convertToTConsensusGroupId(),
-                  SchemaRegionConsensusImpl.getInstance().isLeader(groupId));
-            });
+    if (DataRegionConsensusImpl.getInstance() != null) {
+      DataRegionConsensusImpl.getInstance()
+          .getAllConsensusGroupIds()
+          .forEach(
+              groupId -> {
+                result.put(
+                    groupId.convertToTConsensusGroupId(),
+                    DataRegionConsensusImpl.getInstance().isLeader(groupId));
+              });
+    }
+
+    if (SchemaRegionConsensusImpl.getInstance() != null) {
+      SchemaRegionConsensusImpl.getInstance()
+          .getAllConsensusGroupIds()
+          .forEach(
+              groupId -> {
+                result.put(
+                    groupId.convertToTConsensusGroupId(),
+                    SchemaRegionConsensusImpl.getInstance().isLeader(groupId));
+              });
+    }
     return result;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeRPCServiceImpl.java
@@ -63,7 +63,7 @@ import org.apache.iotdb.db.service.metrics.enums.Tag;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.type.Gauge;
 import org.apache.iotdb.metrics.utils.MetricLevel;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 import org.apache.iotdb.mpp.rpc.thrift.TCancelFragmentInstanceReq;
 import org.apache.iotdb.mpp.rpc.thrift.TCancelPlanFragmentReq;
 import org.apache.iotdb.mpp.rpc.thrift.TCancelQueryReq;
@@ -103,14 +103,14 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-public class InternalServiceImpl implements InternalService.Iface {
+public class DataNodeRPCServiceImpl implements IDataNodeRPCService.Iface {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(InternalServiceImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeRPCServiceImpl.class);
   private final SchemaEngine schemaEngine = SchemaEngine.getInstance();
   private final StorageEngineV2 storageEngine = StorageEngineV2.getInstance();
   private static final double loadBalanceThreshold = 0.1;
 
-  public InternalServiceImpl() {
+  public DataNodeRPCServiceImpl() {
     super();
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeTSServiceImpl.java
@@ -121,9 +121,9 @@ import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onIoTDBException;
 import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onNPEOrUnexpectedException;
 import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onQueryException;
 
-public class DataNodeTSIServiceImpl implements TSIEventHandler {
+public class DataNodeTSServiceImpl implements TSIEventHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeTSIServiceImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataNodeTSServiceImpl.class);
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
@@ -135,7 +135,7 @@ public class DataNodeTSIServiceImpl implements TSIEventHandler {
 
   private final ISchemaFetcher SCHEMA_FETCHER;
 
-  public DataNodeTSIServiceImpl() {
+  public DataNodeTSServiceImpl() {
     if (config.isClusterMode()) {
       PARTITION_FETCHER = ClusterPartitionFetcher.getInstance();
       SCHEMA_FETCHER = ClusterSchemaFetcher.getInstance();

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSIEventHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/TSIEventHandler.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iotdb.db.service.thrift.impl;
 
-import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
-public interface TSIEventHandler extends TSIService.Iface {
+public interface TSIEventHandler extends IClientRPCService.Iface {
   void handleClientExit();
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/io/WALWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/io/WALWriter.java
@@ -19,13 +19,26 @@
 package org.apache.iotdb.db.wal.io;
 
 import org.apache.iotdb.db.wal.buffer.WALEntry;
+import org.apache.iotdb.db.wal.utils.WALFileStatus;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 
 /** WALWriter writes the binary {@link WALEntry} into .wal file. */
 public class WALWriter extends LogWriter {
+  private WALFileStatus walFileStatus = WALFileStatus.CONTAINS_NONE_SEARCH_INDEX;
+
   public WALWriter(File logFile) throws FileNotFoundException {
     super(logFile);
+  }
+
+  public void updateFileStatus(WALFileStatus walFileStatus) {
+    if (walFileStatus == WALFileStatus.CONTAINS_SEARCH_INDEX) {
+      this.walFileStatus = WALFileStatus.CONTAINS_SEARCH_INDEX;
+    }
+  }
+
+  public WALFileStatus getWalFileStatus() {
+    return walFileStatus;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALFileUtils.java
@@ -36,11 +36,11 @@ public class WALFileUtils {
    * versionId is a self-incremented id number, helping to maintain the order of wal files.
    * startSearchIndex is the valid search index of last flushed wal entry. statusCode is the. For
    * example: <br>
-   * _0-0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * _1-5-1.wal: -1, -1, -1, -1 <br>
-   * _2-5-0.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * _3-12-0.wal: 12, 12, 12, 12, 12 <br>
-   * _4-12-0.wal: 12, 13, 14, 15, 16, -1 <br>
+   * _0-0-1.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5-0.wal: -1, -1, -1, -1 <br>
+   * _2-5-1.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12-1.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12-1.wal: 12, 13, 14, 15, 16, -1 <br>
    */
   public static final Pattern WAL_FILE_NAME_PATTERN =
       Pattern.compile(
@@ -105,13 +105,13 @@ public class WALFileUtils {
 
   /**
    * Find index of the file which probably contains target insert plan. <br>
-   * Given wal files [ _0-0-0.wal, _1-5-1.wal, _2-5-0.wal, _3-12-0.wal, _4-12-0.wal ], details as
+   * Given wal files [ _0-0-1.wal, _1-5-0.wal, _2-5-1.wal, _3-12-1.wal, _4-12-1.wal ], details as
    * below: <br>
-   * _0-0-0.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
-   * _1-5-1.wal: -1, -1, -1, -1 <br>
-   * _2-5-0.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
-   * _3-12-0.wal: 12, 12, 12, 12, 12 <br>
-   * _4-12-0.wal: 12, 13, 14, 15, 16, -1 <br>
+   * _0-0-1.wal: 1, 2, 3, -1, -1, 4, 5, -1 <br>
+   * _1-5-0.wal: -1, -1, -1, -1 <br>
+   * _2-5-1.wal: 6, 7, 8, 9, -1, -1, -1, 10, 11, -1, 12, 12 <br>
+   * _3-12-1.wal: 12, 12, 12, 12, 12 <br>
+   * _4-12-1.wal: 12, 13, 14, 15, 16, -1 <br>
    * searching [1, 5] will return 0, searching [6, 12] will return 1, search [13, infinity) will
    * return 3， others will return -1
    *

--- a/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DefaultDriverSchedulerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/execution/schedule/DefaultDriverSchedulerTest.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.mpp.execution.exchange.IMPPDataExchangeManager;
 import org.apache.iotdb.db.mpp.execution.schedule.task.DriverTask;
 import org.apache.iotdb.db.mpp.execution.schedule.task.DriverTaskStatus;
 import org.apache.iotdb.db.utils.stats.CpuTimer;
-import org.apache.iotdb.mpp.rpc.thrift.InternalService;
+import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 
 import io.airlift.units.Duration;
 import org.junit.After;
@@ -309,7 +309,8 @@ public class DefaultDriverSchedulerTest {
     IMPPDataExchangeManager mockMPPDataExchangeManager =
         Mockito.mock(IMPPDataExchangeManager.class);
     manager.setBlockManager(mockMPPDataExchangeManager);
-    InternalService.Client mockMppServiceClient = Mockito.mock(InternalService.Client.class);
+    IDataNodeRPCService.Client mockMppServiceClient =
+        Mockito.mock(IDataNodeRPCService.Client.class);
     ITaskScheduler defaultScheduler = manager.getScheduler();
     QueryId queryId = new QueryId("test");
     FragmentInstanceId instanceId1 =

--- a/server/src/test/java/org/apache/iotdb/db/service/ClientRPCServiceImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/service/ClientRPCServiceImplTest.java
@@ -74,8 +74,8 @@ public class ClientRPCServiceImplTest {
     IoTDB.configManager.init();
     configNode = LocalConfigNode.getInstance();
     configNode.getBelongedSchemaRegionIdWithAutoCreate(new PartialPath("root.ln"));
-    DataRegionConsensusImpl.getInstance().start();
-    SchemaRegionConsensusImpl.getInstance().start();
+    DataRegionConsensusImpl.setupAndGetInstance().start();
+    SchemaRegionConsensusImpl.setupAndGetInstance().start();
   }
 
   @Before

--- a/server/src/test/java/org/apache/iotdb/db/service/ClientRPCServiceImplTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/service/ClientRPCServiceImplTest.java
@@ -39,7 +39,7 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateAlignedTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateMultiTimeSeriesNode;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.write.CreateTimeSeriesNode;
-import org.apache.iotdb.db.service.thrift.impl.InternalServiceImpl;
+import org.apache.iotdb.db.service.thrift.impl.DataNodeRPCServiceImpl;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.mpp.rpc.thrift.TPlanNode;
 import org.apache.iotdb.mpp.rpc.thrift.TSendPlanNodeReq;
@@ -64,9 +64,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class InternalServiceImplTest {
+public class ClientRPCServiceImplTest {
   private static final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
-  InternalServiceImpl internalServiceImpl;
+  DataNodeRPCServiceImpl dataNodeRPCServiceImpl;
   static LocalConfigNode configNode;
 
   @BeforeClass
@@ -85,7 +85,7 @@ public class InternalServiceImplTest {
         .addConsensusGroup(
             ConsensusGroupId.Factory.createFromTConsensusGroupId(regionReplicaSet.getRegionId()),
             genSchemaRegionPeerList(regionReplicaSet));
-    internalServiceImpl = new InternalServiceImpl();
+    dataNodeRPCServiceImpl = new DataNodeRPCServiceImpl();
   }
 
   @After
@@ -146,7 +146,7 @@ public class InternalServiceImplTest {
     request.setConsensusGroupId(regionReplicaSet.getRegionId());
 
     // Use consensus layer to execute request
-    TSendPlanNodeResp response = internalServiceImpl.sendPlanNode(request);
+    TSendPlanNodeResp response = dataNodeRPCServiceImpl.sendPlanNode(request);
 
     Assert.assertTrue(response.accepted);
   }
@@ -222,7 +222,7 @@ public class InternalServiceImplTest {
     request.setConsensusGroupId(regionReplicaSet.getRegionId());
 
     // Use consensus layer to execute request
-    TSendPlanNodeResp response = internalServiceImpl.sendPlanNode(request);
+    TSendPlanNodeResp response = dataNodeRPCServiceImpl.sendPlanNode(request);
 
     Assert.assertTrue(response.accepted);
   }
@@ -309,7 +309,7 @@ public class InternalServiceImplTest {
     request.setConsensusGroupId(regionReplicaSet.getRegionId());
 
     // Use consensus layer to execute request
-    TSendPlanNodeResp response = internalServiceImpl.sendPlanNode(request);
+    TSendPlanNodeResp response = dataNodeRPCServiceImpl.sendPlanNode(request);
 
     Assert.assertTrue(response.accepted);
   }

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
@@ -74,57 +74,57 @@ public class ConsensusReqReaderTest {
 
   /**
    * Generate wal files as below: <br>
-   * _0-0-0.wal: 1,-1 <br>
-   * _1-1-0.wal: 2,2,2 <br>
-   * _2-2-0.wal: 3,3 <br>
-   * _3-3-0.wal: 3,4 <br>
-   * _4-4-0.wal: 4 <br>
-   * _5-4-0.wal: 4,4,5 <br>
-   * _6-5-0.wal: 6 <br>
+   * _0-0-1.wal: 1,-1 <br>
+   * _1-1-1.wal: 2,2,2 <br>
+   * _2-2-1.wal: 3,3 <br>
+   * _3-3-1.wal: 3,4 <br>
+   * _4-4-1.wal: 4 <br>
+   * _5-4-1.wal: 4,4,5 <br>
+   * _6-5-1.wal: 6 <br>
    * 1 - InsertRowNode, 2 - InsertRowsOfOneDeviceNode, 3 - InsertRowsNode, 4 -
    * InsertMultiTabletsNode, 5 - InsertTabletNode, 6 - InsertRowNode
    */
   private void simulateFileScenario01() throws IllegalPathException {
     InsertTabletNode insertTabletNode;
     InsertRowNode insertRowNode;
-    // _0-0-0.wal
+    // _0-0-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(1);
     walNode.log(0, insertRowNode); // 1
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {2});
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // -1
     walNode.rollWALFile();
-    // _1-1-0.wal
+    // _1-1-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(2);
     walNode.log(0, insertRowNode); // 2
     walNode.log(0, insertRowNode); // 2
     walNode.log(0, insertRowNode); // 2
     walNode.rollWALFile();
-    // _2-2-0.wal
+    // _2-2-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(3);
     walNode.log(0, insertRowNode); // 3
     walNode.log(0, insertRowNode); // 3
     walNode.rollWALFile();
-    // _3-3-0.wal
+    // _3-3-1.wal
     insertRowNode.setDevicePath(new PartialPath(devicePath + "test"));
     walNode.log(0, insertRowNode); // 3
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {4});
     insertTabletNode.setSearchIndex(4);
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.rollWALFile();
-    // _4-4-0.wal
+    // _4-4-1.wal
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.rollWALFile();
-    // _5-4-0.wal
+    // _5-4-1.wal
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 4
     insertTabletNode = getInsertTabletNode(devicePath, new long[] {5});
     insertTabletNode.setSearchIndex(5);
     walNode.log(0, insertTabletNode, 0, insertTabletNode.getRowCount()); // 5
     walNode.rollWALFile();
-    // _6-5-0.wal
+    // _6-5-1.wal
     insertRowNode = getInsertRowNode(devicePath);
     insertRowNode.setSearchIndex(6);
     WALFlushListener walFlushListener = walNode.log(0, insertRowNode); // 6

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -259,7 +259,7 @@ public class WALNodeTest {
     }
     walNode.onMemTableFlushed(memTable);
     walNode.onMemTableCreated(new PrimitiveMemTable(), tsFilePath);
-    // check existence of _0-0-0.wal file
+    // check existence of _0-0-0.wal file and _1-0-1.wal file
     assertTrue(
         new File(
                 logDirectory
@@ -270,7 +270,7 @@ public class WALNodeTest {
         new File(
                 logDirectory
                     + File.separator
-                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX))
             .exists());
     walNode.deleteOutdatedFiles();
     assertFalse(
@@ -283,7 +283,7 @@ public class WALNodeTest {
         new File(
                 logDirectory
                     + File.separator
-                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_NONE_SEARCH_INDEX))
+                    + WALFileUtils.getLogFileName(1, 0, WALFileStatus.CONTAINS_SEARCH_INDEX))
             .exists());
     // check flush listeners
     try {

--- a/server/src/test/resources/datanode1conf/iotdb-datanode.properties
+++ b/server/src/test/resources/datanode1conf/iotdb-datanode.properties
@@ -26,7 +26,7 @@ internal_port=9003
 data_region_consensus_port=40010
 schema_region_consensus_port=50030
 
-config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
+target_config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
 
 system_dir=target/datanode1/system
 data_dirs=target/datanode1/data

--- a/server/src/test/resources/datanode2conf/iotdb-datanode.properties
+++ b/server/src/test/resources/datanode2conf/iotdb-datanode.properties
@@ -26,7 +26,7 @@ internal_port=9005
 data_region_consensus_port=40012
 schema_region_consensus_port=50032
 
-config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
+target_config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
 
 system_dir=target/datanode2/system
 data_dirs=target/datanode2/data

--- a/server/src/test/resources/datanode3conf/iotdb-datanode.properties
+++ b/server/src/test/resources/datanode3conf/iotdb-datanode.properties
@@ -26,7 +26,7 @@ internal_port=9007
 data_region_consensus_port=40014
 schema_region_consensus_port=50034
 
-config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
+target_config_nodes=0.0.0.0:22277,0.0.0.0:22279,0.0.0.0:22281
 
 system_dir=target/datanode3/system
 data_dirs=target/datanode3/data

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBJDBCDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBJDBCDataSet.java
@@ -20,10 +20,10 @@
 package org.apache.iotdb.rpc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -49,7 +49,7 @@ public class IoTDBJDBCDataSet {
   public static final int START_INDEX = 2;
   public String sql;
   public boolean isClosed = false;
-  public TSIService.Iface client;
+  public IClientRPCService.Iface client;
   public List<String> columnNameList; // no deduplication
   public List<String> columnTypeList; // no deduplication
   public Map<String, Integer>
@@ -87,7 +87,7 @@ public class IoTDBJDBCDataSet {
       boolean ignoreTimeStamp,
       long queryId,
       long statementId,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       TSQueryDataSet queryDataSet,
       int fetchSize,
@@ -188,7 +188,7 @@ public class IoTDBJDBCDataSet {
       boolean ignoreTimeStamp,
       long queryId,
       long statementId,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       TSQueryDataSet queryDataSet,
       int fetchSize,

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -20,10 +20,10 @@
 package org.apache.iotdb.rpc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -48,7 +48,7 @@ public class IoTDBRpcDataSet {
   public static final int START_INDEX = 2;
   public String sql;
   public boolean isClosed = false;
-  public TSIService.Iface client;
+  public IClientRPCService.Iface client;
   public List<String> columnNameList; // no deduplication
   public List<String> columnTypeList; // no deduplication
   public Map<String, Integer>
@@ -86,7 +86,7 @@ public class IoTDBRpcDataSet {
       boolean ignoreTimeStamp,
       long queryId,
       long statementId,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       TSQueryDataSet queryDataSet,
       int fetchSize,

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -22,9 +22,9 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxDBService;
 import org.apache.iotdb.protocol.influxdb.rpc.thrift.InfluxTSStatus;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 
 import java.lang.reflect.Proxy;
 import java.text.SimpleDateFormat;
@@ -63,11 +63,11 @@ public class RpcUtils {
   public static final TSStatus SUCCESS_STATUS =
       new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
 
-  public static TSIService.Iface newSynchronizedClient(TSIService.Iface client) {
-    return (TSIService.Iface)
+  public static IClientRPCService.Iface newSynchronizedClient(IClientRPCService.Iface client) {
+    return (IClientRPCService.Iface)
         Proxy.newProxyInstance(
             RpcUtils.class.getClassLoader(),
-            new Class[] {TSIService.Iface.class},
+            new Class[] {IClientRPCService.Iface.class},
             new SynchronizedHandler(client));
   }
 

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/SynchronizedHandler.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/SynchronizedHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.rpc;
 
-import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
 import org.apache.thrift.TException;
 
@@ -28,9 +28,9 @@ import java.lang.reflect.Method;
 
 public class SynchronizedHandler implements InvocationHandler {
 
-  private final TSIService.Iface client;
+  private final IClientRPCService.Iface client;
 
-  public SynchronizedHandler(TSIService.Iface client) {
+  public SynchronizedHandler(IClientRPCService.Iface client) {
     this.client = client;
   }
 

--- a/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.rpc.RedirectException;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSAppendSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSCloseSessionReq;
 import org.apache.iotdb.service.rpc.thrift.TSCreateAlignedTimeseriesReq;
@@ -36,7 +37,6 @@ import org.apache.iotdb.service.rpc.thrift.TSDeleteDataReq;
 import org.apache.iotdb.service.rpc.thrift.TSDropSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSInsertRecordReq;
 import org.apache.iotdb.service.rpc.thrift.TSInsertRecordsOfOneDeviceReq;
 import org.apache.iotdb.service.rpc.thrift.TSInsertRecordsReq;
@@ -77,7 +77,7 @@ public class SessionConnection {
       "Fail to reconnect to server. Please check server status";
   private Session session;
   private TTransport transport;
-  private TSIService.Iface client;
+  private IClientRPCService.Iface client;
   private long sessionId;
   private long statementId;
   private ZoneId zoneId;
@@ -118,9 +118,9 @@ public class SessionConnection {
     }
 
     if (session.enableRPCCompression) {
-      client = new TSIService.Client(new TCompactProtocol(transport));
+      client = new IClientRPCService.Client(new TCompactProtocol(transport));
     } else {
-      client = new TSIService.Client(new TBinaryProtocol(transport));
+      client = new IClientRPCService.Client(new TBinaryProtocol(transport));
     }
     client = RpcUtils.newSynchronizedClient(client);
 
@@ -188,7 +188,7 @@ public class SessionConnection {
     }
   }
 
-  protected TSIService.Iface getClient() {
+  protected IClientRPCService.Iface getClient() {
     return client;
   }
 

--- a/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.session;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.IoTDBRpcDataSet;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -50,7 +50,7 @@ public class SessionDataSet implements AutoCloseable {
       Map<String, Integer> columnNameIndex,
       long queryId,
       long statementId,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       TSQueryDataSet queryDataSet,
       boolean ignoreTimeStamp) {
@@ -77,7 +77,7 @@ public class SessionDataSet implements AutoCloseable {
       Map<String, Integer> columnNameIndex,
       long queryId,
       long statementId,
-      TSIService.Iface client,
+      IClientRPCService.Iface client,
       long sessionId,
       TSQueryDataSet queryDataSet,
       boolean ignoreTimeStamp,

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -240,7 +240,7 @@ struct TShowRegionResp {
   2: optional list<common.TRegionInfo> regionInfoList;
 }
 
-service ConfigIService {
+service IConfigNodeRPCService {
 
   /* DataNode */
 

--- a/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/thrift-confignode/src/main/thrift/confignode.thrift
@@ -202,7 +202,9 @@ struct TConfigNodeRegisterReq {
   6: required i64 defaultTTL
   7: required i64 timePartitionInterval
   8: required i32 schemaReplicationFactor
-  9: required i32 dataReplicationFactor
+  9: required double schemaRegionPerDataNode
+  10: required i32 dataReplicationFactor
+  11: required double dataRegionPerProcessor
 }
 
 struct TConfigNodeRegisterResp {

--- a/thrift/src/main/thrift/client.thrift
+++ b/thrift/src/main/thrift/client.thrift
@@ -406,7 +406,7 @@ struct TSDropSchemaTemplateReq {
   2: required string templateName
 }
 
-service TSIService {
+service IClientRPCService {
   TSOpenSessionResp openSession(1:TSOpenSessionReq req);
 
   common.TSStatus closeSession(1:TSCloseSessionReq req);

--- a/thrift/src/main/thrift/datanode.thrift
+++ b/thrift/src/main/thrift/datanode.thrift
@@ -132,7 +132,7 @@ struct TCancelFragmentInstanceReq {
 
 struct TCancelResp {
   1: required bool cancelled
-  2: optional string messsage
+  2: optional string message
 }
 
 struct TSchemaFetchRequest {
@@ -170,17 +170,17 @@ struct THeartbeatResp {
   4: optional i16 memory
 }
 
-service InternalService {
+service IDataNodeRPCService {
 
   // -----------------------------------For Data Node-----------------------------------------------
 
   /**
-  * disptcher FragmentInstance to remote node for query request
+  * dispatch FragmentInstance to remote node for query request
   */
   TSendFragmentInstanceResp sendFragmentInstance(TSendFragmentInstanceReq req);
 
   /**
-  * disptcher PlanNode to remote node for write request in order to save resource
+  * dispatch PlanNode to remote node for write request in order to save resource
   */
   TSendPlanNodeResp sendPlanNode(TSendPlanNodeReq req);
 


### PR DESCRIPTION
## Support set TTL in new cluster

### add confireLeader
### In ConfigNode, the ConfigNode checks whether StorageGroup exists. 
### If StorageGroup exists, the ConfigNode obtains the DataNode corresponding to the StorageGroup that has Dataregion based on the partition table information.
###  sets the TTL of Dataregion on the DataNode.